### PR TITLE
fix(reservation): allow re-booking same slot after cancellation

### DIFF
--- a/src/domain/user/dao/reservation_repository.py
+++ b/src/domain/user/dao/reservation_repository.py
@@ -73,6 +73,31 @@ class ReservationRepository:
         return ReservationVO.model_validate(reservation)
 
 
+    async def find_active_duplicate(self, db: AsyncSession,
+                                    schedule_id: int,
+                                    dtstart: int,
+                                    dtend: int,
+                                    my_user_id: int,
+                                    user_id: int) -> Optional[ReservationVO]:
+        # Cancelled reservations are kept as REJECT rows, so they must be
+        # excluded here — otherwise re-booking the same slot is blocked.
+        stmt: Select = select(Reservation).where(
+            and_(
+                Reservation.schedule_id == schedule_id,
+                Reservation.dtstart == dtstart,
+                Reservation.dtend == dtend,
+                Reservation.my_user_id == my_user_id,
+                Reservation.user_id == user_id,
+                Reservation.my_status != BookingStatus.REJECT,
+                Reservation.status != BookingStatus.REJECT,
+            )
+        )
+        reservation = await get_first_template(db, stmt)
+        if not reservation:
+            return None
+        return ReservationVO.model_validate(reservation)
+
+
     async def find_all(self, db: AsyncSession,
                        query: Dict,
                        dtstart: Optional[int] = None,

--- a/src/domain/user/service/reservation_service.py
+++ b/src/domain/user/service/reservation_service.py
@@ -277,16 +277,15 @@ class ReservationService:
 
     async def check_duplicate_reservation(self, db: AsyncSession, reservation_dto: ReservationDTO):
         # 检查是否已存在完全相同的预订记录
+        # 取消後 row 仍保留並標記為 REJECT，需排除掉才能讓使用者重訂同一時段
         try:
-            existing_reservation = await self.reservation_repo.find_one(
+            existing_reservation = await self.reservation_repo.find_active_duplicate(
                 db,
-                {
-                    'schedule_id': reservation_dto.schedule_id,
-                    'dtstart': reservation_dto.dtstart,
-                    'dtend': reservation_dto.dtend,
-                    'my_user_id': reservation_dto.my_user_id,
-                    'user_id': reservation_dto.user_id,
-                }
+                schedule_id=reservation_dto.schedule_id,
+                dtstart=reservation_dto.dtstart,
+                dtend=reservation_dto.dtend,
+                my_user_id=reservation_dto.my_user_id,
+                user_id=reservation_dto.user_id,
             )
 
             if existing_reservation:


### PR DESCRIPTION
## Summary
- Mentee 在 reservation 被取消後，重訂同一個 schedule + 同一時段會被 backend 擋下並回 `Duplicate reservation already exists`。
- 根因：取消只把 `my_status` / `status` 設為 `REJECT`（reservations table 沒有 soft-delete 欄位），但 `check_duplicate_reservation` 用 `find_one` 撈取重複時 **沒有排除 REJECT**，導致已取消的舊紀錄一直擋住新預約。
- 修法：新增 `ReservationRepository.find_active_duplicate()`，在 DB 層面用 `and_(...)` 把 `my_status != REJECT` 與 `status != REJECT` 加進 query（沿用同檔 `has_active_or_future_reservations` 既有的 pattern）。`check_duplicate_reservation` 改用此新方法。
- 不動 `find_one` 的行為，避免影響 `get_participant_vo` / `get_prev_participant_vo` 等仍需要取得歷史 (含 REJECT) 紀錄的呼叫端。
- `check_my_accepted_bookings` 的時段衝突檢查行為不變。

## Test plan
- [ ] Mentee 預約某 mentor 的時段 → 成功
- [ ] Mentee（或 mentor）取消該 reservation → 成功
- [ ] Mentee 重新預約**完全相同**的 `schedule_id` + `dtstart` + `dtend` → 預期成功（修這支 bug 之前會失敗）
- [ ] Mentee 同時段已有 `ACCEPT` 中的另一筆 reservation 時，再預約應仍被擋下（不破壞既有衝突檢查）
- [ ] 同 mentee 跨多次 cancel → re-book 同時段，每次都應成功
- [ ] Regression：mentor accept / reject、reschedule (`create_new_and_reject_previous`) 流程不受影響

Closes Xchange-Taiwan/X-Talent-Tracker#158