### PR TITLE
fix(reservation): join Profile on counterparty only

### DIFF
--- a/src/domain/user/dao/reservation_repository.py
+++ b/src/domain/user/dao/reservation_repository.py
@@ -257,8 +257,8 @@ class ReservationRepository:
             join(
                 Reservation,
                 Profile,
-                (Reservation.my_user_id == Profile.user_id or Reservation.user_id == Profile.user_id),
-                isouter=True
+                Reservation.user_id == Profile.user_id,
+                isouter=True,
             )
         )
         # for key, value in query.items():


### PR DESCRIPTION
## Summary
- The `get_user_reservations` join used Python `or` between two SQLAlchemy equality expressions, which short-circuits at expression-build time. The rendered SQL only joined `Profile` on one side, so `participant.name / avatar / job_title / years_of_experience` came back blank in the API response.
- Drop the OR and join `Profile` directly on `Reservation.user_id` (the counterparty). The `WHERE` clause already constrains `my_user_id` to the viewer, so `Reservation.user_id` is unambiguously the participant.
- `ReservationInfoVO.from_sender_model` only assigns Profile fields to `participant` (sender side never reads them), so a single join on `user_id` is sufficient — no schema change.

Fixes [Xchange-Taiwan/X-Talent-Tracker#139](https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/139).

## Test plan
- [ ] Local: hit `GET /v1/users/{user_id}/reservations?state=MENTOR_HISTORY&batch=10` for a user with past reservations and verify `participant.name / avatar / job_title / years_of_experience` are populated.
- [ ] Local: same check for `MENTEE_HISTORY`, `MENTOR_UPCOMING`, `MENTEE_UPCOMING`, `MENTOR_PENDING`, `MENTEE_PENDING` (the join is shared across all states).
- [ ] FE smoke: on dev, open Mentor Reservation Page → History tab and Mentee Reservation Page → History tab, confirm counterparty name / avatar / job title render correctly.