### PR TITLE
fix(reservation): exclude REJECTED rows from PENDING list

### DIFF
--- a/src/domain/user/dao/reservation_repository.py
+++ b/src/domain/user/dao/reservation_repository.py
@@ -286,7 +286,13 @@ class ReservationRepository:
                 stmt = stmt.where(Reservation.dtend >= query.next_dtend)
 
         elif query.state == ReservationListState.MENTOR_PENDING.value:
+            # Either side rejecting ends the reservation, so PENDING must exclude
+            # rows where my_status or status is REJECT — otherwise a self-cancel
+            # before the counterparty responds keeps the row in PENDING because
+            # the other side's status is still PENDING (mirrors HISTORY filter).
             stmt = stmt.where(
+                (Reservation.my_status != BookingStatus.REJECT) &
+                (Reservation.status != BookingStatus.REJECT) &
                 ((Reservation.my_status == BookingStatus.PENDING) |
                 (Reservation.status == BookingStatus.PENDING)) &
                 (Reservation.my_role == RoleType.MENTOR) &
@@ -297,6 +303,8 @@ class ReservationRepository:
 
         elif query.state == ReservationListState.MENTEE_PENDING.value:
             stmt = stmt.where(
+                (Reservation.my_status != BookingStatus.REJECT) &
+                (Reservation.status != BookingStatus.REJECT) &
                 ((Reservation.my_status == BookingStatus.PENDING) |
                 (Reservation.status == BookingStatus.PENDING)) &
                 (Reservation.my_role == RoleType.MENTEE) &


### PR DESCRIPTION
## Summary
- Mentee/Mentor 在對方尚未回應的 PENDING 預約上自我取消後,該筆仍出現在 `MENTEE_PENDING` / `MENTOR_PENDING` 清單,前端 refetch 後看起來像是「取消失敗」。
- 根因:`reservation_repository.py` 的 PENDING filter 用 `OR`,只要任一側 `status == PENDING` 就匹配。自我取消後該使用者那列為 `my_status=REJECT, status=PENDING`(對方那側仍 PENDING),仍命中 PENDING filter,同時也命中 HISTORY filter → 同一筆同時出現在兩個 tab。
- 修法:在 PENDING filter 前面加上 `my_status != REJECT AND status != REJECT` 守門,被 REJECT 的列直接排除(已被 HISTORY filter 收走)。MENTOR_PENDING 與 MENTEE_PENDING 兩段對稱修。

## Test plan
- [ ] Mentee book → Mentor 未回應前 Mentee 取消 → MENTEE_PENDING 不再出現該筆,MENTEE_HISTORY 出現。
- [ ] Mentor 收到 booking 後直接 REJECT → MENTOR_PENDING 不再出現該筆,MENTOR_HISTORY 出現。
- [ ] Mentor ACCEPT 後 Mentee 仍看得到於 MENTEE_PENDING(因雙方尚未都 ACCEPT,status 還是 PENDING)。
- [ ] Mentor 與 Mentee 都 ACCEPT → 進入 UPCOMING,不在 PENDING(原本就如此,確認沒回歸)。
- [ ] 過期(dtend < now)的 PENDING/REJECT 都歸 HISTORY,不在 PENDING(原本就如此)。

> Backend 目前沒有 pytest infrastructure(requirements.txt 沒有 pytest,test/ 只有空 __init__.py)。本 PR 僅做最小 fix,測試以手動覆蓋。如需後續補 pytest 基底可另開 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)