### PR TITLE
feat(reservation): expose avatar_updated_at on RUserInfoVO

### DIFF
--- a/src/domain/user/dao/reservation_repository.py
+++ b/src/domain/user/dao/reservation_repository.py
@@ -251,6 +251,7 @@ class ReservationRepository:
             Reservation.previous_reserve,
             Profile.name,
             Profile.avatar,
+            Profile.avatar_updated_at,
             Profile.job_title,
             Profile.years_of_experience,
         ).select_from(

--- a/src/domain/user/model/reservation_model.py
+++ b/src/domain/user/model/reservation_model.py
@@ -146,6 +146,7 @@ class RUserInfoVO(BaseModel):
                                   pattern=f'^({BookingStatus.ACCEPT.value}|{BookingStatus.REJECT.value}|{BookingStatus.PENDING.value})$')
     name: Optional[str] = ''
     avatar: Optional[str] = ''
+    avatar_updated_at: Optional[int] = None
     job_title: Optional[str] = ''
     years_of_experience: Optional[str] = '0'
 
@@ -250,6 +251,7 @@ class ReservationInfoVO(BaseModel):
                 status=reservation.status,
                 name=reservation.name,
                 avatar=reservation.avatar,
+                avatar_updated_at=reservation.avatar_updated_at,
                 job_title=reservation.job_title,
                 years_of_experience=reservation.years_of_experience,
             ),


### PR DESCRIPTION
## Summary

- Reservation list responses returned the counterparty avatar URL but omitted `avatar_updated_at`, so frontend reservation cards keep showing a stale (up to 30-day cached) avatar after the user uploads a new one.
- `get_user_reservations` now selects `Profile.avatar_updated_at` along with the other Profile join columns.
- `RUserInfoVO` gains `avatar_updated_at: Optional[int]`, populated for the participant in `ReservationInfoVO.from_sender_model`.

The sender object is the requesting user themselves, so it follows the existing pattern of leaving counterparty-only profile fields unset on `sender` — frontend already has the logged-in user's avatar from elsewhere.

Closes Xchange-Taiwan/X-Talent-Tracker#243 (User-side scope)

## Test plan

- [ ] Smoke `/reservations` for a mentor and a mentee and confirm `participant.avatar_updated_at` is present (and matches the counterparty Profile row)
- [ ] Have the counterparty re-upload an avatar; next `/reservations` fetch returns a new `avatar_updated_at`
- [ ] Existing reservation flows (new booking, accept/reject, history) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)