### PR TITLE
fix(profile): bump avatar_updated_at via dedicated touch endpoint

### DIFF
--- a/src/app/mentor_profile/upsert.py
+++ b/src/app/mentor_profile/upsert.py
@@ -55,6 +55,29 @@ class MentorProfile:
             )
         return res
 
+    async def touch_avatar(
+        self,
+        db: AsyncSession,
+        user_id: int,
+        background_tasks: BackgroundTasks,
+    ) -> int:
+        """Bump ``avatar_updated_at`` after a successful avatar upload.
+
+        Stable per-user S3 keys mean ``profile.avatar`` doesn't change on
+        re-upload, so the standard upsert path can't detect the bytes have
+        changed. The BFF calls this directly after the upload to refresh the
+        cache buster, then re-publishes to Search for mentor users so the
+        index stays in sync within the existing 60s SLA.
+        """
+        new_value, is_mentor = await self.profile_service.touch_avatar(
+            db, user_id
+        )
+        if is_mentor:
+            background_tasks.add_task(
+                self.notify_service.updated_user_profile, user_id=user_id
+            )
+        return new_value
+
 
     async def upsert_mentor_profile(
         self,

--- a/src/domain/user/dao/profile_repository.py
+++ b/src/domain/user/dao/profile_repository.py
@@ -1,6 +1,6 @@
-from typing import Optional
+from typing import Optional, Tuple
 
-from sqlalchemy import select, Select, delete as sa_delete
+from sqlalchemy import select, Select, delete as sa_delete, update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config.exception import NotFoundException
@@ -64,4 +64,30 @@ class ProfileRepository:
     async def delete_profile(self, db: AsyncSession, user_id: int) -> None:
         stmt = sa_delete(Profile).where(Profile.user_id == user_id)
         await db.execute(stmt)
+
+    async def bump_avatar_updated_at(
+        self, db: AsyncSession, user_id: int
+    ) -> Tuple[int, bool]:
+        """Set ``avatar_updated_at`` to ``current_seconds()`` and return the
+        value plus ``is_mentor``.
+
+        The S3 avatar key is per-user and stable, so a re-upload doesn't change
+        ``profile.avatar``. The BFF calls this after a successful upload (POST
+        to presigned URL or server-side upload) to refresh the cache buster
+        without going through the full profile upsert path. Returns
+        ``is_mentor`` so the caller can decide whether to re-publish to Search.
+        """
+        now = current_seconds()
+        stmt = (
+            sa_update(Profile)
+            .where(Profile.user_id == user_id)
+            .values(avatar_updated_at=now)
+            .returning(Profile.avatar_updated_at, Profile.is_mentor)
+        )
+        result = await db.execute(stmt)
+        row = result.first()
+        if row is None:
+            raise NotFoundException(msg=f"No such user with id: {user_id}")
+        await db.commit()
+        return row.avatar_updated_at, bool(row.is_mentor)
 

--- a/src/domain/user/model/user_model.py
+++ b/src/domain/user/model/user_model.py
@@ -13,6 +13,9 @@ from .common_model import (
 log = logging.getLogger(__name__)
 
 
+class AvatarTouchVO(BaseModel):
+    avatar_updated_at: int
+
 
 class ProfileDTO(BaseModel):
     user_id: Optional[int]

--- a/src/domain/user/service/profile_service.py
+++ b/src/domain/user/service/profile_service.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Optional, Coroutine, Any, Set, Dict, List, Union
+from typing import Optional, Coroutine, Any, Set, Dict, List, Tuple, Union
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -65,6 +65,18 @@ class ProfileService:
         except Exception as e:
             log.error(f"upsert_profile error: %s", str(e))
             err_msg = getattr(e, "msg", "upsert profile response failed")
+            raise_http_exception(e, msg=err_msg)
+
+    async def touch_avatar(
+        self, db: AsyncSession, user_id: int
+    ) -> Tuple[int, bool]:
+        try:
+            return await self.__profile_repository.bump_avatar_updated_at(
+                db, user_id
+            )
+        except Exception as e:
+            log.error(f"touch_avatar error: %s", str(e))
+            err_msg = getattr(e, "msg", "touch avatar response failed")
             raise_http_exception(e, msg=err_msg)
 
     async def convert_to_profile_vo(

--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -63,6 +63,29 @@ async def upsert_profile(
     return res_success(data=jsonable_encoder(res))
 
 
+@router.post('/{user_id}/avatar/touch',
+             responses=idempotent_response('touch_avatar', user.AvatarTouchVO))
+async def touch_avatar(
+        background_tasks: BackgroundTasks,
+        user_id: int = Path(...),
+        db: AsyncSession = Depends(db_session),
+        mentor_profile_app: MentorProfile = Depends(get_mentor_profile_app),
+):
+    """Bump avatar_updated_at after a successful avatar upload.
+
+    Per-user S3 keys are stable, so re-uploads don't change profile.avatar's
+    URL — the standard upsert path can't tell the bytes have changed. The
+    BFF calls this from the avatar-upload completion flow to refresh the
+    cache buster.
+    """
+    new_value: int = await mentor_profile_app.touch_avatar(
+        db=db,
+        user_id=user_id,
+        background_tasks=background_tasks,
+    )
+    return res_success(data={'avatar_updated_at': new_value})
+
+
 @router.get('/{user_id}/{language}/profile',
             responses=idempotent_response('get_profile', user.ProfileVO))
 async def get_profile(


### PR DESCRIPTION
## Summary

S3 avatar key 是 per-user 固定的（`files/{user_id}/avatar`），re-upload 直接 overwrite in place、`profile.avatar` 的 URL 不會變。`assign_avatar_updated_at`（#74 加的）用「新 URL vs 舊 URL」來決定要不要 bump `avatar_updated_at` — 對任何走 presigned-URL 上傳流程的使用者來說，這個比較永遠相等，所以 cache buster 永遠不會被 bump，每個觀看者都會繼續看到舊圖，直到下次有別的事件觸發 profile row 更新為止。

這個 PR 加一個獨立的 `POST /v1/users/{user_id}/avatar/touch` endpoint，BFF 在上傳成功後直接打它 — 把 bump 點對齊真正的「上傳事件」，而不是靠 URL diff 反推（在 stable URL 設計下這個推論已經失效）。

### Changes

- **`src/domain/user/dao/profile_repository.py`** — `bump_avatar_updated_at(db, user_id)` 跑一次 atomic `UPDATE ... RETURNING avatar_updated_at, is_mentor`，route 一次拿到 timestamp + is_mentor。沒對應 profile row 時丟 `NotFoundException`。
- **`src/domain/user/service/profile_service.py`** — `touch_avatar` 包一層標準錯誤處理。
- **`src/app/mentor_profile/upsert.py`** — `MentorProfile.touch_avatar` 沿用 `upsert_profile` 的 pattern：使用者是 mentor 才把 `notify_service.updated_user_profile` 排成 background task，讓 Search service 透過現有 SQS pipeline 拿到新值。
- **`src/router/v1/user.py`** — 新 route `POST /{user_id}/avatar/touch`。沒 body，回傳 `{ avatar_updated_at: int }`。
- **`src/domain/user/model/user_model.py`** — 小 VO `AvatarTouchVO` 給 typed OpenAPI response。

### 為什麼開獨立 endpoint，而不是改 `assign_avatar_updated_at`

URL-change heuristic 只在「stable-key re-upload」這個情境下會壞 — 當 avatar URL 真的改變（例如 Google OAuth 圖切到自己上傳的）時它仍然是對的。把 bump 移到上傳完成的 handler，可以保留那條 happy path，又把 bump 點對齊真實的「bytes 變了」事件，而不是依附在「下次 profile edit」這個副作用上。

### Coordinated PRs

- BFF：Xchange-Taiwan/X-Career-BFF — 加 `POST /v1/storage/avatar/touch/{user_id}` proxy 打到這裡。
- Frontend：Xchange-Taiwan/X-Talent-Frontend — `updateAvatar.ts` 在 `uploadToS3WithPresignedPost` 成功後打 BFF endpoint。

Merge 順序：User → BFF → Frontend（FE 依賴 BFF route 存在；BFF 依賴本 PR）。

### 不在 scope 內

- 把 legacy 既有的 `avatar_updated_at IS NULL` 但已有 avatar 的 row 補值（之前討論過、這次不做 — 那些使用者下次上傳就會被補上）。
- Search-side index 工作（Xchange-Taiwan/X-Career-Search PR #16）— 那是消費端；這裡是生產端。

## Test plan

- [ ] 部署到 dev，FE 用 presigned-URL 流程傳新 avatar
- [ ] 確認 `POST /v1/users/{user_id}/avatar/touch` 有被打到（server logs）
- [ ] `GET /v1/mentors/{user_id}/zh_TW/profile` 透過 BFF 拿到非 null 的 `avatar_updated_at`
- [ ] Mentor：確認 `UPSERT_MENTOR_PROFILE` SQS event 有發（Search index 拿到新值）
- [ ] 非 mentor：沒有 SQS event（沿用現有 `upsert_profile` 的 is_mentor gate）
- [ ] 沒 profile row 的 user_id 回 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
