### PR TITLE
fix(profile): bump avatar_updated_at when FE signals a refresh

### DIFF
--- a/src/domain/user/dao/profile_repository.py
+++ b/src/domain/user/dao/profile_repository.py
@@ -13,15 +13,30 @@ from src.infra.util.time_util import current_seconds
 async def assign_avatar_updated_at(db: AsyncSession, dto: ProfileDTO) -> None:
     """Set ``dto.avatar_updated_at`` ahead of an upsert.
 
-    Bumps to ``current_seconds()`` only when the avatar URL actually changes
-    so unrelated profile edits don't invalidate the avatar's cache buster.
-    Preserves the previous timestamp otherwise.
+    Per-user S3 avatar URLs are stable, so URL-comparison can't tell when
+    the bytes have changed. The frontend signals an avatar refresh by
+    sending a non-null ``avatar_updated_at`` in the upsert payload — when
+    we see that signal, bump using the server clock (the client value is
+    treated as a flag, not the source of truth).
+
+    Falls back to the legacy URL-comparison heuristic for callers that
+    don't send the signal (e.g. avatar switching between Google OAuth and
+    a custom upload, where the URL legitimately changes). Otherwise the
+    previous timestamp is preserved so unrelated profile edits don't
+    invalidate the cache buster.
     """
     if dto is None or dto.user_id is None:
         return
 
     stmt: Select = select(Profile).filter(Profile.user_id == dto.user_id)
     existing: Optional[Profile] = await get_first_template(db, stmt)
+
+    if dto.avatar_updated_at is not None:
+        # Frontend signaled an avatar refresh. Always overwrite with the
+        # server clock so a malicious or skewed client time can't poison
+        # the cache buster.
+        dto.avatar_updated_at = current_seconds()
+        return
 
     new_avatar = (dto.avatar or '').strip()
     prev_avatar = (getattr(existing, 'avatar', None) or '') if existing else ''


### PR DESCRIPTION
## 這個 PR 在解什麼

使用者換頭像之後，**別人在 mentor-pool / reservation 卡片看到的還是舊圖**。原因是 S3 avatar key 是 per-user 固定的（`files/{user_id}/avatar`），re-upload 直接 overwrite 同一個物件，URL 不會變。`assign_avatar_updated_at` 用「新 URL vs 舊 URL」判斷有沒有變、再決定要不要 bump cache buster — 對 stable URL 而言這條 if 永遠不會 trigger，所以時間戳一直沒被更新。

這個 PR 改判斷依據：**FE 只要明確帶 `avatar_updated_at` 上來就 bump，不再依賴 URL 比對**。

## 改了什麼

只動 `src/domain/user/dao/profile_repository.py` 的 `assign_avatar_updated_at`。

新流程：

1. **FE 帶 `avatar_updated_at`（不是 None）** → 用 `current_seconds()` 蓋過 dto 的值再寫入 DB
   - 不信 client clock —— FE 送什麼數字無所謂、server 自己算
   - 唯一的「換了頭像」訊號
2. **FE 沒帶（fallback）** → 走原本的 URL 比對 heuristic
   - URL 真的變了（例如 Google OAuth 圖切到自己上傳的）就 bump
   - URL 沒變就保留原值
3. **沒有 existing row** → 維持原本「啥都不寫」的行為

```python
if dto.avatar_updated_at is not None:
    # FE signal — server 用自己的 clock 蓋過去
    dto.avatar_updated_at = current_seconds()
    return

# fallback: 原本的 URL 比對 heuristic
new_avatar = (dto.avatar or '').strip()
prev_avatar = (getattr(existing, 'avatar', None) or '') if existing else ''
if new_avatar and new_avatar != prev_avatar:
    dto.avatar_updated_at = current_seconds()
elif existing is not None:
    dto.avatar_updated_at = getattr(existing, 'avatar_updated_at', None)
```

## 為什麼要保留 fallback

雖然主流程會走「FE 帶訊號」，但保留原本的 URL 比對作為 backstop 比較安全：
- 萬一以後有別的 caller 走 `upsert_profile` 沒帶 signal，URL 真的變了還是會 bump
- 例如 Google OAuth 帳號第一次上傳自己的頭像（從 Google URL 變成 S3 URL）
- 純加法、沒拿掉任何能 bump 的條件

## 配套 PR

| Repo | PR | 角色 |
|---|---|---|
| **X-Career-User**（本 PR） | — | 後端 bump 邏輯 |
| X-Talent-Frontend | Xchange-Taiwan/X-Talent-Frontend — `fix/avatar-rollback-on-cancel` | FE 在 PUT 時帶 `avatar_updated_at` 訊號；取消時把舊圖傳回 S3 |

部署順序：先 User、再 FE。FE 沒部署前後端只是多個 fallback，舊行為一致。

## Test plan

- [ ] 部署到 dev
- [ ] FE 換頭像 + 儲存：`GET /v1/mentors/{user_id}/zh_TW/profile` 看到 `avatar_updated_at` 是新的 epoch（接近 server 當下時間）
- [ ] FE 不換頭像、只改 about：`avatar_updated_at` 不變（fallback URL 比對 → 沒變、保留）
- [ ] 直接打 PUT body 帶 `avatar_updated_at: 999999999` 假值：DB 裡寫進去的是 server 的 `current_seconds()`，不是 999999999
- [ ] 沒對應 profile row 時行為不變
- [ ] mentor user 的 SQS publish 到 Search 流程仍正常（`updated_user_profile` background task 會 republish profile，包含新 `avatar_updated_at`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
