### PR TITLE
fix(reservation): allow re-booking same slot after cancellation

### DIFF
--- a/src/domain/user/dao/reservation_repository.py
+++ b/src/domain/user/dao/reservation_repository.py
@@ -23,9 +23,9 @@ class ReservationRepository:
         stmt = select(exists().where(
             and_(
                 Reservation.my_user_id == user_id,
-                Reservation.dtend >= current_seconds(),
                 Reservation.my_status != BookingStatus.REJECT,
                 Reservation.status != BookingStatus.REJECT,
+                Reservation.dtend >= current_seconds(),
             )
         ))
         result = await db.scalar(stmt)
@@ -83,11 +83,11 @@ class ReservationRepository:
         # excluded here — otherwise re-booking the same slot is blocked.
         stmt: Select = select(Reservation).where(
             and_(
+                Reservation.my_user_id == my_user_id,
                 Reservation.schedule_id == schedule_id,
+                Reservation.user_id == user_id,
                 Reservation.dtstart == dtstart,
                 Reservation.dtend == dtend,
-                Reservation.my_user_id == my_user_id,
-                Reservation.user_id == user_id,
                 Reservation.my_status != BookingStatus.REJECT,
                 Reservation.status != BookingStatus.REJECT,
             )

--- a/src/infra/db/sql/init/user_init.sql
+++ b/src/infra/db/sql/init/user_init.sql
@@ -145,8 +145,13 @@ CREATE TABLE IF NOT EXISTS reservations (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE UNIQUE INDEX uidx_reservation_user_dtstart_dtend_schedule_id_user_id
-    ON reservations(my_user_id, dtstart, dtend, schedule_id, user_id);
+-- Partial unique: only enforce uniqueness for non-cancelled reservations.
+-- Cancellations leave a REJECT row behind; without WHERE, re-booking the
+-- same slot fails the unique constraint even though find_active_duplicate
+-- (reservation_repository.py) already excludes REJECT at the app layer.
+CREATE UNIQUE INDEX uidx_reservation_active_user_dtstart_dtend_schedule_id_user_id
+    ON reservations(my_user_id, dtstart, dtend, schedule_id, user_id)
+    WHERE my_status <> 'REJECT' AND "status" <> 'REJECT';
 CREATE INDEX idx_reservation_user_my_status_status_dtend
     ON reservations(my_user_id, my_status, "status", dtend);
 CREATE INDEX idx_reservation_user_my_status_dtstart_dtend
@@ -174,6 +179,32 @@ CREATE TABLE IF NOT EXISTS activities (
 
 CREATE INDEX idx_activities_mentor_reservation_id ON activities(mentor_reservation_id);
 CREATE INDEX idx_activities_mentee_reservation_id ON activities(mentee_reservation_id);
+
+
+-- Idempotent migration for existing deployments: replace the old full unique
+-- index with a partial one so cancelled (REJECT) rows no longer block
+-- re-booking the same slot. Safe to re-run on fresh installs.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname = 'uidx_reservation_user_dtstart_dtend_schedule_id_user_id'
+    ) THEN
+        DROP INDEX public.uidx_reservation_user_dtstart_dtend_schedule_id_user_id;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname = 'uidx_reservation_active_user_dtstart_dtend_schedule_id_user_id'
+    ) THEN
+        CREATE UNIQUE INDEX uidx_reservation_active_user_dtstart_dtend_schedule_id_user_id
+            ON reservations(my_user_id, dtstart, dtend, schedule_id, user_id)
+            WHERE my_status <> 'REJECT' AND "status" <> 'REJECT';
+    END IF;
+END $$;
+
 
 --以下測試用插入資料
 INSERT INTO interests (category, "subject_group", "language", "subject", "desc")

--- a/src/infra/db/sql/init/user_init.sql
+++ b/src/infra/db/sql/init/user_init.sql
@@ -180,32 +180,6 @@ CREATE TABLE IF NOT EXISTS activities (
 CREATE INDEX idx_activities_mentor_reservation_id ON activities(mentor_reservation_id);
 CREATE INDEX idx_activities_mentee_reservation_id ON activities(mentee_reservation_id);
 
-
--- Idempotent migration for existing deployments: replace the old full unique
--- index with a partial one so cancelled (REJECT) rows no longer block
--- re-booking the same slot. Safe to re-run on fresh installs.
-DO $$
-BEGIN
-    IF EXISTS (
-        SELECT 1 FROM pg_indexes
-        WHERE schemaname = 'public'
-          AND indexname = 'uidx_reservation_user_dtstart_dtend_schedule_id_user_id'
-    ) THEN
-        DROP INDEX public.uidx_reservation_user_dtstart_dtend_schedule_id_user_id;
-    END IF;
-
-    IF NOT EXISTS (
-        SELECT 1 FROM pg_indexes
-        WHERE schemaname = 'public'
-          AND indexname = 'uidx_reservation_active_user_dtstart_dtend_schedule_id_user_id'
-    ) THEN
-        CREATE UNIQUE INDEX uidx_reservation_active_user_dtstart_dtend_schedule_id_user_id
-            ON reservations(my_user_id, dtstart, dtend, schedule_id, user_id)
-            WHERE my_status <> 'REJECT' AND "status" <> 'REJECT';
-    END IF;
-END $$;
-
-
 --以下測試用插入資料
 INSERT INTO interests (category, "subject_group", "language", "subject", "desc")
 VALUES (


### PR DESCRIPTION
## Summary
- Replace the full unique index on `reservations(my_user_id, dtstart, dtend, schedule_id, user_id)` with a **partial** unique index that excludes `REJECT` rows.
- Aligns the DB invariant with the app-layer `find_active_duplicate` check, which already excludes REJECT.

## Bug
1. Mentee books slot X → row inserted with status `ACCEPT`/`PENDING`.
2. Mentee cancels → `update_reservation_status` flips `my_status`/`status` to `REJECT` (row is **kept**, not deleted).
3. Mentee tries to re-book slot X:
   - App-layer `check_duplicate_reservation` → `find_active_duplicate` excludes REJECT, so passes ✅
   - `save_all` INSERT fails because the old REJECT row still occupies the unique-index slot ❌

## Fix
- `src/infra/db/sql/init/user_init.sql` — unique index now has `WHERE my_status <> ''REJECT'' AND status <> ''REJECT''`.
- Pre-launch, so no migration block — dev DB will be recreated from `user_init.sql`.

## Test plan
- [ ] Recreate dev DB from `user_init.sql` → new partial index `uidx_reservation_active_user_dtstart_dtend_schedule_id_user_id` exists.
- [ ] Mentee books a slot, cancels, re-books the same slot → succeeds (currently fails on dev).
- [ ] Mentee books a slot, then attempts a second active booking for the exact same slot without cancelling → still blocked (uniqueness preserved for active rows).
- [ ] History view still shows the cancelled reservation (REJECT row preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)