### PR TITLE
feat(#229): publish user_tags on profile/tags updates (SQS payload)

### DIFF
--- a/src/app/_di/injection.py
+++ b/src/app/_di/injection.py
@@ -174,8 +174,11 @@ def get_notify_service(
     mentor_service: MentorService = Depends(get_mentor_service),
     experience_service: ExperienceService = Depends(get_experience_service),
     mq_adapter: SqsMqAdapter = Depends(get_sqs_mq_adapter),
+    tag_repository: TagRepository = Depends(get_tag_dao),
 ):
-    return NotifyService(mentor_service, experience_service, mq_adapter)
+    return NotifyService(
+        mentor_service, experience_service, mq_adapter, tag_repository
+    )
 
 
 def get_mentor_profile_app(

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -102,10 +102,16 @@ class MentorProfileVO(ProfileVO):
             is_mentor=self.is_mentor,
         )
 
-    def to_dto_json(self):
+    def to_dto_json(self, user_tags: Optional[List[Dict]] = None):
+        # `user_tags` is grafted in alongside `experiences` so the SQS payload
+        # carries everything Search needs to populate `profiles_v2.user_tags`.
+        # Caller passes the list; None or omitted leaves it out (legacy callers
+        # are unaffected — Search treats absence as "no v2 update needed").
         dto = self.from_dto()
         dto_dict = jsonable_encoder(dto)
         dto_dict.update({'experiences': jsonable_encoder(self.experiences)})
+        if user_tags is not None:
+            dto_dict['user_tags'] = jsonable_encoder(user_tags)
         return dto_dict
 
 

--- a/src/domain/mentor/service/notify_service.py
+++ b/src/domain/mentor/service/notify_service.py
@@ -1,10 +1,11 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 from fastapi import BackgroundTasks
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.infra.template.service_api import IServiceApi
 from src.infra.mq.sqs_mq_adapter import SqsMqAdapter
 from src.infra.databse import SessionLocal
+from src.domain.user.dao.tag_repository import TagRepository
 from src.domain.user.service.profile_service import ProfileService
 from src.domain.user.model import user_model as user
 from src.domain.mentor.service.mentor_service import MentorService
@@ -32,10 +33,31 @@ class NotifyService:
         mentor_service: MentorService,
         experience_service: ExperienceService,
         mq_adapter: SqsMqAdapter,
+        tag_repository: TagRepository,
     ):
         self.mentor_service = mentor_service
         self.exp_service: ExperienceService = experience_service
         self.mq_adapter = mq_adapter
+        self.tag_repository = tag_repository
+
+    async def _serialize_user_tags(
+        self, db: AsyncSession, user_id: int
+    ) -> List[Dict]:
+        # Hydrates current user_tags rows into the SQS-friendly shape the
+        # Search service expects on `profiles_v2.user_tags`. Joins to Tag so
+        # kind / subject_group / language travel with the row.
+        rows = await self.tag_repository.get_user_tags_with_tag(db, user_id)
+        return [
+            {
+                "tag_id": ut.tag_id,
+                "kind": tag.kind,
+                "intent": ut.intent,
+                "subject_group": tag.subject_group,
+                "subject": tag.subject,
+                "language": tag.language,
+            }
+            for ut, tag in rows
+        ]
 
     async def updated_user_profile(self, user_id: int):
         """Triggered by PUT /users/profile — syncs the full mentor profile document."""
@@ -46,8 +68,9 @@ class NotifyService:
                         db, user_id, DEFAULT_LANGUAGE
                     )
                 )
+                user_tags = await self._serialize_user_tags(db, user_id)
             payload = {
-                **mentor_profile.to_dto_json(),
+                **mentor_profile.to_dto_json(user_tags=user_tags),
                 "action": "UPSERT_MENTOR_PROFILE",
             }
             await self.mq_adapter.publish_message(payload, group_id=str(user_id))
@@ -60,8 +83,10 @@ class NotifyService:
         """Triggered by PUT /mentors/mentor_profile — updates mentor-specific fields."""
         try:
             user_id = mentor_profile.user_id
+            async with SessionLocal() as db:
+                user_tags = await self._serialize_user_tags(db, user_id)
             payload = {
-                **mentor_profile.to_dto_json(),
+                **mentor_profile.to_dto_json(user_tags=user_tags),
                 "action": "PUT_MENTOR_PROFILE",
             }
             await self.mq_adapter.publish_message(payload, group_id=str(user_id))
@@ -87,8 +112,10 @@ class NotifyService:
                 mentor_profile: mentor.MentorProfileVO = mentor.MentorProfileVO(
                     user_id=user_id, experiences=experiences
                 )
+                async with SessionLocal() as db:
+                    user_tags = await self._serialize_user_tags(db, user_id)
                 payload = {
-                    **mentor_profile.to_dto_json(),
+                    **mentor_profile.to_dto_json(user_tags=user_tags),
                     "action": "PATCH_MENTOR_PROFILE",
                 }
                 await self.mq_adapter.publish_message(payload, group_id=str(user_id))
@@ -96,6 +123,27 @@ class NotifyService:
 
         except Exception as e:
             log.error(f"[NotifyService] failed to publish experience update, user_id={user_id}: {e}")
+
+    async def notify_updated_user_tags(self, user_id: int):
+        """Triggered by PUT /v1/users/{id}/tags — fires a fresh full UPSERT
+        so Search re-syncs both v1 (legacy nested arrays, unchanged) and v2
+        (`profiles_v2.user_tags`, populated from the freshly-written tags)."""
+        try:
+            async with SessionLocal() as db:
+                mentor_profile: mentor.MentorProfileVO = (
+                    await self.mentor_service.get_mentor_profile_by_id(
+                        db, user_id, DEFAULT_LANGUAGE
+                    )
+                )
+                user_tags = await self._serialize_user_tags(db, user_id)
+            payload = {
+                **mentor_profile.to_dto_json(user_tags=user_tags),
+                "action": "UPSERT_MENTOR_PROFILE",
+            }
+            await self.mq_adapter.publish_message(payload, group_id=str(user_id))
+            log.info(f"[NotifyService] published UPSERT_MENTOR_PROFILE (tags), user_id={user_id}")
+        except Exception as e:
+            log.error(f"[NotifyService] failed to publish user tags update, user_id={user_id}: {e}")
 
     async def notify_delete_mentor_profile(self, user_id: int) -> None:
         try:

--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -37,8 +37,10 @@ from ...app._di.injection import (
     get_profession_service,
     get_profile_service,
     get_mentor_profile_app,
+    get_notify_service,
     get_tag_service,
 )
+from ...domain.mentor.service.notify_service import NotifyService
 
 log = logging.getLogger(__name__)
 
@@ -178,12 +180,18 @@ async def list_user_tags(
 @router.put('/{user_id}/tags',
             responses=idempotent_response('replace_user_tags', tag.UserTagsUpsertVO))
 async def replace_user_tags(
+        background_tasks: BackgroundTasks,
         user_id: int = Path(...),
         body: tag.UserTagsUpsertDTO = Body(...),
         db: AsyncSession = Depends(db_session),
         tag_service: TagService = Depends(get_tag_service),
+        notify_service: NotifyService = Depends(get_notify_service),
 ):
     res: tag.UserTagsUpsertVO = await tag_service.replace_user_tags(
         db, user_id, body
     )
+    # Fire after the DB commit inside replace_user_tags so the SQS payload
+    # serializer reads the freshly-written rows. Background-task dispatch
+    # keeps the request latency unaffected.
+    background_tasks.add_task(notify_service.notify_updated_user_tags, user_id)
     return res_success(data=jsonable_encoder(res))


### PR DESCRIPTION
## Summary

Closes the data-flow gap between the v2 `PUT /v1/users/{id}/tags` endpoint (PR #85) and the Search service `profiles_v2` index (Search PR #17). Without this PR, frontend writes to `/tags` landed in `user_tags` table but never reached the search index — so `filter_offers` (and the upcoming `filter_skills` / `filter_positions` / `filter_topics` / `filter_expertises` cutovers in #230-#232) returned empty results.

## What changed

### `MentorProfileVO.to_dto_json(user_tags=...)`

Grafts the supplied `user_tags` array into the SQS payload, parallel to the existing `experiences` graft. Default `None` preserves every legacy caller.

### `NotifyService`

- `_serialize_user_tags(db, user_id)` — joins `user_tags ↔ tag` and materializes the list shape Search expects on `profiles_v2.user_tags`.
- `notify_updated_user_tags(user_id)` — new method, fires `UPSERT_MENTOR_PROFILE` with current tags + profile. Used by `PUT /tags`.
- All existing publish methods (`updated_user_profile`, `updated_mentor_profile`, `notify_updated_user_experiences`) now hydrate `user_tags` too — any profile-shaped change keeps `profiles_v2.user_tags` in sync with the source of truth.

### `get_notify_service` DI

Threads `TagRepository` through.

### `PUT /v1/users/{id}/tags` route

Accepts `BackgroundTasks` and fires `notify_updated_user_tags` after `replace_user_tags` commits. Request latency unchanged (background dispatch).

## Additive only

No v1 SQS field is removed. No existing payload key changes shape. Search treats `user_tags` absence as a no-op (the v2 doc just doesn't get a tag refresh on that message), so partial rollouts are safe.

## Test plan

- [ ] `cd X-Talent-infra && docker compose up -d --build` — User + Search both up
- [ ] `PUT /user-service/api/v1/users/1/tags` with `{"kind":"what_i_offer","intent":"OFFER","subject_groups":["career_coaching"]}` → 200; Search service log shows `_upsert_mentor` + v2 dual-write
- [ ] `curl http://localhost:9200/profiles_v2/_doc/1` shows the doc with `user_tags` populated
- [ ] `PUT /user-service/api/v1/users/1/profile` (existing endpoint) — Search log shows the same SQS payload now also carries `user_tags` (no regression in v1 path)

Refs Xchange-Taiwan/X-Talent-Tracker#229, Xchange-Taiwan/X-Talent-Tracker#226

Generated with [Claude Code](https://claude.com/claude-code)
