### PR TITLE
fix(#229): expose Tag.desc through TagVO/UserTagVO + SQS payload

### DIFF
--- a/src/domain/mentor/service/notify_service.py
+++ b/src/domain/mentor/service/notify_service.py
@@ -45,7 +45,7 @@ class NotifyService:
     ) -> List[Dict]:
         # Hydrates current user_tags rows into the SQS-friendly shape the
         # Search service expects on `profiles_v2.user_tags`. Joins to Tag so
-        # kind / subject_group / language travel with the row.
+        # kind / subject_group / language / desc travel with the row.
         rows = await self.tag_repository.get_user_tags_with_tag(db, user_id)
         return [
             {
@@ -55,6 +55,7 @@ class NotifyService:
                 "subject_group": tag.subject_group,
                 "subject": tag.subject,
                 "language": tag.language,
+                "desc": tag.desc,
             }
             for ut, tag in rows
         ]

--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -11,6 +11,9 @@ class TagVO(BaseModel):
     subject_group: Optional[str] = None
     language: Optional[str] = None
     subject: Optional[str] = ''
+    # Free-form per-tag metadata (icon, color, display hints, etc.) — mirrors
+    # the v1 `_INTEREST_NESTED_PROPS.desc` JSONB field. Stored as Tag.desc.
+    desc: Optional[Dict[str, Any]] = None
 
     model_config = {"from_attributes": True}
 
@@ -22,6 +25,7 @@ class UserTagVO(BaseModel):
     subject_group: Optional[str] = None
     language: Optional[str] = None
     subject: Optional[str] = ''
+    desc: Optional[Dict[str, Any]] = None
 
 
 class UserTagListVO(BaseModel):

--- a/src/domain/user/service/tag_service.py
+++ b/src/domain/user/service/tag_service.py
@@ -40,6 +40,7 @@ class TagService:
                     subject_group=tag.subject_group,
                     language=tag.language,
                     subject=tag.subject,
+                    desc=tag.desc,
                 )
                 for ut, tag in rows
             ]


### PR DESCRIPTION
## Summary

Closes a gap left by #228 + #229: the `tags` table has a `desc = Column(JSONB)` column (free-form per-tag metadata, mirrors v1 `_INTEREST_NESTED_PROPS.desc`) but neither `TagVO` nor `UserTagVO` exposed it. As a result:

- `GET /v1/users/{id}/tags` returned rows without `desc`
- `TagService.list_user_tags` ignored the column even though `get_user_tags_with_tag` already joins `Tag` in
- `NotifyService._serialize_user_tags` built SQS payloads without `desc`, so `profiles_v2.user_tags` lost it on every dual-write

## What changed

- `TagVO` / `UserTagVO`: add `desc: Optional[Dict[str, Any]] = None`
- `TagService.list_user_tags`: populate `desc=tag.desc` from the joined Tag row
- `NotifyService._serialize_user_tags`: include `desc` in the per-tag dict so the Search service can index it onto `profiles_v2.user_tags`

## Additive only

Default `None` keeps existing callers happy when a Tag row has NULL `desc`.

## Sibling PRs

- BFF: mirrors the same field in its `UserTagVO` so the proxy passes it through (separate PR in X-Career-BFF).
- Search: adds `desc` as a dynamic object in `_USER_TAG_NESTED_PROPS` so OpenSearch indexes it (separate PR in X-Career-Search).

## Test plan

- [ ] `cd X-Talent-infra && docker compose up -d --build`
- [ ] Insert a tag row with a non-null desc directly: `INSERT INTO "x-career-dev".tags (kind, subject_group, language, subject, desc) VALUES ('skill', 'typescript', 'zh_TW', '', '{"icon":"ts"}'::jsonb);`
- [ ] Hit `PUT /v1/users/1/tags` with `{"kind":"skill","intent":"WANT","subject_groups":["typescript"]}`
- [ ] `GET /v1/users/1/tags?intent=WANT` → response includes `desc: {"icon":"ts"}`
- [ ] Search service log shows the SQS payload contains `desc` on the user_tags array entry

Refs Xchange-Taiwan/X-Talent-Tracker#229, Xchange-Taiwan/X-Talent-Tracker#226

Generated with [Claude Code](https://claude.com/claude-code)
