### PR TITLE
feat(#226): two-layer tag schema + kind consolidation + catalog (User)

### DIFF
--- a/src/app/_di/injection.py
+++ b/src/app/_di/injection.py
@@ -130,6 +130,7 @@ def get_mentor_service(
     interest_service: InterestService = Depends(get_interest_service),
     profession_service: ProfessionService = Depends(get_profession_service),
     profile_service: ProfileService = Depends(get_profile_service),
+    tag_service: TagService = Depends(get_tag_service),
 ) -> MentorService:
     return MentorService(
         mentor_repository,
@@ -137,6 +138,7 @@ def get_mentor_service(
         interest_service,
         profession_service,
         profile_service,
+        tag_service,
     )
 
 

--- a/src/config/constant.py
+++ b/src/config/constant.py
@@ -78,11 +78,15 @@ class Sorting(Enum):
 
 
 class TagKind(Enum):
-    EXPERTISE = 'expertise'
+    # Two intent axes share the same kind:
+    #   skill   — WANT (mentee wants to learn) or OFFER (mentor can teach)
+    #   topic   — WANT (mentee wants to discuss) or OFFER (mentor can mentor on)
+    #   position — WANT (mentee interested in this role)
+    # `expertise` and `what_i_offer` were collapsed into `skill` / `topic`
+    # respectively under the two-layer redesign — intent flag does the work.
     SKILL = 'skill'
     POSITION = 'position'
     TOPIC = 'topic'
-    WHAT_I_OFFER = 'what_i_offer'
 
 
 class TagIntent(Enum):

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from fastapi.encoders import jsonable_encoder
 from ...user.model.common_model import ProfessionListVO
+from ...user.model.tag_model import UserTagVO
 from ...user.model.user_model import *
 from .experience_model import ExperienceVO
 from ....config.conf import *
@@ -62,6 +63,11 @@ class MentorProfileVO(ProfileVO):
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
     expertises: Optional[ProfessionListVO] = None
     experiences: Optional[List[ExperienceVO]] = Field(default_factory=list)
+    # #226 two-layer: hydrated unified user-tags view. Includes parent_subject_group
+    # so the frontend can render the two-layer breadcrumb (group → leaf) in one
+    # round trip without a separate GET /tags call. Populated by MentorService
+    # via TagService.list_user_tags. None means the caller did not hydrate.
+    user_tags: Optional[List[UserTagVO]] = None
 
     @staticmethod
     def of(mentor_profile_dto: MentorProfileDTO) -> 'MentorProfileVO':

--- a/src/domain/mentor/service/mentor_service.py
+++ b/src/domain/mentor/service/mentor_service.py
@@ -7,23 +7,39 @@ from src.domain.user.dao.profile_repository import ProfileRepository
 from src.domain.user.service.interest_service import InterestService
 from src.domain.user.service.profession_service import ProfessionService
 from src.domain.user.service.profile_service import ProfileService
+from src.domain.user.service.tag_service import TagService
 import logging
 
 log = logging.getLogger(__name__)
 
 class MentorService:
     def __init__(self, mentor_repository: MentorRepository, profile_repository: ProfileRepository,
-                 interest_service: InterestService, profession_service: ProfessionService, profile_service: ProfileService):
+                 interest_service: InterestService, profession_service: ProfessionService,
+                 profile_service: ProfileService, tag_service: TagService):
         self.__mentor_repository: MentorRepository = mentor_repository
         self.__interest_service: InterestService = interest_service
         self.__profession_service: ProfessionService = profession_service
         self.__profile_repository: ProfileRepository = profile_repository
         self.__profile_service: ProfileService = profile_service
+        self.__tag_service: TagService = tag_service
+
+    async def __hydrate_user_tags(
+        self, db: AsyncSession, vo: MentorProfileVO, user_id: int
+    ) -> None:
+        # Best-effort: failure to hydrate user_tags should not fail the whole
+        # /mentor_profile read — caller can still do a separate GET /tags.
+        try:
+            tag_list = await self.__tag_service.list_user_tags(db, user_id)
+            vo.user_tags = tag_list.user_tags
+        except Exception as e:
+            log.warning("hydrate user_tags failed for user %s: %s", user_id, e)
+            vo.user_tags = []
 
     async def upsert_mentor_profile(self, db: AsyncSession, profile_dto: MentorProfileDTO) -> MentorProfileVO:
         try:
             res_dto: MentorProfileDTO = await self.__mentor_repository.upsert_mentor(db, profile_dto)
             res_vo: MentorProfileVO = await self.__profile_service.convert_to_mentor_profile_vo(db, res_dto, language=profile_dto.language)
+            await self.__hydrate_user_tags(db, res_vo, res_dto.user_id)
             return res_vo
         except Exception as e:
             log.error(f'upsert_mentor_profile error: %s', str(e))
@@ -36,7 +52,9 @@ class MentorService:
             mentor_dto: MentorProfileDTO = await self.__mentor_repository.get_mentor_profile_by_id(db, user_id)
             if mentor_dto is None:
                 raise NotFoundException(msg=f"No such user with id: {user_id}")
-            return await self.__profile_service.convert_to_mentor_profile_vo(db, mentor_dto, language=language)
+            res_vo: MentorProfileVO = await self.__profile_service.convert_to_mentor_profile_vo(db, mentor_dto, language=language)
+            await self.__hydrate_user_tags(db, res_vo, user_id)
+            return res_vo
         except Exception as e:
             log.error(f'get_mentor_profile_by_id error: %s', str(e))
             err_msg = getattr(e, 'msg', 'get mentor profile response failed')

--- a/src/domain/mentor/service/notify_service.py
+++ b/src/domain/mentor/service/notify_service.py
@@ -56,6 +56,7 @@ class NotifyService:
                 "subject": tag.subject,
                 "language": tag.language,
                 "desc": tag.desc,
+                "parent_subject_group": tag.parent_subject_group,
             }
             for ut, tag in rows
         ]

--- a/src/domain/user/dao/tag_repository.py
+++ b/src/domain/user/dao/tag_repository.py
@@ -34,6 +34,22 @@ class TagRepository:
             stmt = stmt.filter(Tag.language == language)
         return await get_all_template(db, stmt)
 
+    async def list_catalog(
+        self,
+        db: AsyncSession,
+        kind: TagKind,
+        language: str,
+    ) -> List[Type[Tag]]:
+        # Returns every tag row for (kind, language) — both groups and leaves.
+        # Service layer groups them into the nested catalog VO.
+        stmt: Select = (
+            select(Tag)
+            .filter(Tag.kind == kind.value)
+            .filter(Tag.language == language)
+            .order_by(Tag.parent_subject_group.nullsfirst(), Tag.subject_group)
+        )
+        return await get_all_template(db, stmt)
+
     async def find_tag(
         self,
         db: AsyncSession,

--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -14,6 +14,10 @@ class TagVO(BaseModel):
     # Free-form per-tag metadata (icon, color, display hints, etc.) — mirrors
     # the v1 `_INTEREST_NESTED_PROPS.desc` JSONB field. Stored as Tag.desc.
     desc: Optional[Dict[str, Any]] = None
+    # Two-layer hierarchy: NULL on top-level group rows (and on industry, which
+    # is intentionally single-layer); non-NULL on leaf rows, where it points at
+    # the group's `subject_group` within the same `kind`.
+    parent_subject_group: Optional[str] = None
 
     model_config = {"from_attributes": True}
 
@@ -26,6 +30,7 @@ class UserTagVO(BaseModel):
     language: Optional[str] = None
     subject: Optional[str] = ''
     desc: Optional[Dict[str, Any]] = None
+    parent_subject_group: Optional[str] = None
 
 
 class UserTagListVO(BaseModel):
@@ -34,6 +39,9 @@ class UserTagListVO(BaseModel):
 
 class UserTagsUpsertDTO(BaseModel):
     # Replace all of (user_id, kind, intent) with the supplied subject_groups.
+    # `subject_groups` items must be LEAF subject_groups for kind ∈
+    # {skill, position, topic} (group-level rows are catalog scaffolding,
+    # not user selections). The service rejects non-leaf entries.
     kind: TagKind
     intent: TagIntent
     subject_groups: List[str] = []
@@ -46,3 +54,25 @@ class UserTagsUpsertVO(BaseModel):
     intent: str
     tag_ids: List[int] = []
     replaced: bool = True
+
+
+class TagCatalogLeafVO(BaseModel):
+    tag_id: int
+    subject_group: str
+    subject: str
+    language: str
+    desc: Optional[Dict[str, Any]] = None
+
+
+class TagCatalogGroupVO(BaseModel):
+    subject_group: str
+    subject: str
+    language: str
+    desc: Optional[Dict[str, Any]] = None
+    leaves: List[TagCatalogLeafVO] = []
+
+
+class TagCatalogVO(BaseModel):
+    kind: str
+    language: str
+    groups: List[TagCatalogGroupVO] = []

--- a/src/domain/user/service/tag_service.py
+++ b/src/domain/user/service/tag_service.py
@@ -5,9 +5,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config.conf import DEFAULT_LANGUAGE
 from src.config.constant import TagIntent, TagKind
-from src.config.exception import raise_http_exception
+from src.config.exception import (
+    ClientException,
+    raise_http_exception,
+)
 from src.domain.user.dao.tag_repository import TagRepository
 from src.domain.user.model.tag_model import (
+    TagCatalogGroupVO,
+    TagCatalogLeafVO,
+    TagCatalogVO,
     UserTagListVO,
     UserTagsUpsertDTO,
     UserTagsUpsertVO,
@@ -41,6 +47,7 @@ class TagService:
                     language=tag.language,
                     subject=tag.subject,
                     desc=tag.desc,
+                    parent_subject_group=tag.parent_subject_group,
                 )
                 for ut, tag in rows
             ]
@@ -58,6 +65,12 @@ class TagService:
         # Replace all (user_id, kind, intent) tags with the supplied
         # subject_groups. find-or-create canonical tag per subject_group,
         # then delete-existing + insert-new in a single transaction.
+        # Leaf-only: each supplied subject_group must resolve to a row whose
+        # parent_subject_group IS NOT NULL (group rows are catalog scaffolding,
+        # not user selections). Missing rows are auto-created — legacy callers
+        # that arrived before catalog seed still work; the resulting orphan
+        # row carries parent_subject_group=NULL and a follow-up seed pass
+        # links it to its proper parent.
         try:
             language = dto.language or DEFAULT_LANGUAGE
             kind_value = dto.kind.value
@@ -71,6 +84,13 @@ class TagService:
                 if tag is None:
                     tag = await self.__tag_repository.create_tag(
                         db, kind_value, subject_group, language
+                    )
+                elif tag.parent_subject_group is None:
+                    raise ClientException(
+                        msg=(
+                            f"subject_group '{subject_group}' is a top-level "
+                            f"group; user selections must reference leaf tags."
+                        )
                     )
                 tag_ids.append(tag.id)
 
@@ -90,7 +110,75 @@ class TagService:
                 tag_ids=tag_ids,
                 replaced=True,
             )
+        except ClientException:
+            await db.rollback()
+            raise
         except Exception as e:
             await db.rollback()
             log.error("replace_user_tags error: %s", str(e))
+            raise_http_exception(e, msg="Internal Server Error")
+
+    async def get_catalog(
+        self,
+        db: AsyncSession,
+        kind: TagKind,
+        language: str,
+    ) -> TagCatalogVO:
+        # Group rows (parent_subject_group IS NULL) anchor the catalog;
+        # leaves attach by matching their parent_subject_group to a group's
+        # subject_group within the same kind. Industry passes through as
+        # a flat list of "group" rows with empty `leaves` arrays.
+        try:
+            rows = await self.__tag_repository.list_catalog(db, kind, language)
+
+            groups_by_key: dict = {}
+            ordered_keys: List[str] = []
+            orphan_leaves: List = []
+
+            for tag in rows:
+                if tag.parent_subject_group is None:
+                    if tag.subject_group not in groups_by_key:
+                        groups_by_key[tag.subject_group] = TagCatalogGroupVO(
+                            subject_group=tag.subject_group,
+                            subject=tag.subject or '',
+                            language=tag.language,
+                            desc=tag.desc,
+                            leaves=[],
+                        )
+                        ordered_keys.append(tag.subject_group)
+                else:
+                    leaf = TagCatalogLeafVO(
+                        tag_id=tag.id,
+                        subject_group=tag.subject_group,
+                        subject=tag.subject or '',
+                        language=tag.language,
+                        desc=tag.desc,
+                    )
+                    parent = groups_by_key.get(tag.parent_subject_group)
+                    if parent is not None:
+                        parent.leaves.append(leaf)
+                    else:
+                        orphan_leaves.append((tag.parent_subject_group, leaf))
+
+            # Late-arriving leaves whose group came after them in the iteration
+            # already attached above; orphans here truly have no group row in
+            # this language. Surface them under a synthetic catch-all group so
+            # the catalog stays usable rather than silently dropping rows.
+            if orphan_leaves:
+                catchall = TagCatalogGroupVO(
+                    subject_group='',
+                    subject='',
+                    language=language,
+                    leaves=[leaf for _, leaf in orphan_leaves],
+                )
+                groups_by_key[''] = catchall
+                ordered_keys.append('')
+
+            return TagCatalogVO(
+                kind=kind.value,
+                language=language,
+                groups=[groups_by_key[k] for k in ordered_keys],
+            )
+        except Exception as e:
+            log.error("get_catalog error: %s", str(e))
             raise_http_exception(e, msg="Internal Server Error")

--- a/src/infra/db/orm/init/user_init.py
+++ b/src/infra/db/orm/init/user_init.py
@@ -154,6 +154,10 @@ class Tag(Base):
     language = Column(String(10))
     subject = Column(Text, nullable=False, default='')
     desc = Column(JSONB)
+    # Two-layer hierarchy (#226): NULL = top-level group row (or industry, which
+    # is intentionally single-layer); non-NULL = leaf row whose parent is the
+    # group with `subject_group == parent_subject_group` and the same `kind`.
+    parent_subject_group = Column(String(40), nullable=True, index=True)
 
 
 class UserTag(Base):

--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -195,3 +195,18 @@ async def replace_user_tags(
     # keeps the request latency unaffected.
     background_tasks.add_task(notify_service.notify_updated_user_tags, user_id)
     return res_success(data=jsonable_encoder(res))
+
+
+@router.get('/{language}/tags/catalog',
+            responses=idempotent_response('get_tag_catalog', tag.TagCatalogVO))
+async def get_tag_catalog(
+        language: str = Path(...),
+        kind: TagKind = Query(...),
+        db: AsyncSession = Depends(db_session),
+        tag_service: TagService = Depends(get_tag_service),
+):
+    # Returns the two-layer catalog for `kind` in `language`. Industry comes
+    # back as a flat list of group rows (no leaves) since it is intentionally
+    # single-layer.
+    res: tag.TagCatalogVO = await tag_service.get_catalog(db, kind, language)
+    return res_success(data=jsonable_encoder(res))


### PR DESCRIPTION
## Summary

Implements the **two-layer tag schema** + **kind consolidation** for #226. This is the User-side half of a coordinated 3-PR backend change (BFF + Search ship in sibling PRs).

## Schema (manual ALTER on dev — no migration in repo)

```sql
ALTER TABLE tags ADD COLUMN parent_subject_group VARCHAR(40) NULL;
CREATE INDEX idx_tags_kind_parent ON tags (kind, parent_subject_group);
```

## Two-layer model

| Row type | `parent_subject_group` | Example |
|---|---|---|
| Group (top-level) | `NULL` | `kind=skill, subject_group='software_dev', subject='軟體開發'` |
| Leaf | references parent's `subject_group` | `kind=skill, subject_group='frontend_dev', subject='前端開發', parent_subject_group='software_dev'` |
| Industry | always `NULL` | `kind=industry` rows have no leaves — single-layer by design |

## TagKind consolidation (A3)

Drops `EXPERTISE` and `WHAT_I_OFFER`. Remaining kinds: `SKILL`, `POSITION`, `TOPIC`. Mentor offerings now use `intent=OFFER` against the same tree as mentee wants:

| Concept | Before | After |
|---|---|---|
| Mentor's expertise | `kind=expertise, intent=OFFER` | `kind=skill, intent=OFFER` |
| Mentor's what-I-offer | `kind=what_i_offer, intent=OFFER` | `kind=topic, intent=OFFER` |

One catalog tree per concept; no duplicate seed rows. Frontend `kind` mapping changes are deferred (per pre-launch / "frontend later" direction).

## Code changes

| File | Change |
|---|---|
| `src/infra/db/orm/init/user_init.py` | `Tag.parent_subject_group = Column(String(40), nullable=True, index=True)` |
| `src/config/constant.py` | `TagKind` keeps only `SKILL`, `POSITION`, `TOPIC` |
| `src/domain/user/model/tag_model.py` | `TagVO` / `UserTagVO` add `parent_subject_group`. New `TagCatalogVO`, `TagCatalogGroupVO`, `TagCatalogLeafVO` |
| `src/domain/user/dao/tag_repository.py` | New `list_catalog(db, kind, language)` |
| `src/domain/user/service/tag_service.py` | `list_user_tags` hydrates `parent_subject_group`. `replace_user_tags` adds leaf-only validation. New `get_catalog` |
| `src/domain/mentor/service/notify_service.py` | SQS payload `_serialize_user_tags` carries `parent_subject_group` |
| `src/domain/mentor/model/mentor_model.py` | `MentorProfileVO.user_tags: Optional[List[UserTagVO]]` |
| `src/domain/mentor/service/mentor_service.py` | `__hydrate_user_tags` helper; `get_mentor_profile_by_id` + `upsert_mentor_profile` populate `user_tags` |
| `src/app/_di/injection.py` | `MentorService` gets `TagService` injected |
| `src/router/v1/user.py` | New `GET /v1/users/{language}/tags/catalog?kind=` |

## API additions

- **`GET /v1/users/{language}/tags/catalog?kind=skill`** → `TagCatalogVO` with nested `groups[].leaves[]`. Industry returns flat groups with empty `leaves`.
- **`GET /v1/mentors/{user_id}/{language}/mentor_profile`** response now includes `user_tags: List[UserTagVO]` alongside the legacy `interested_positions / skills / topics / expertises / experiences` — additive, no removals.
- **`PUT /v1/users/{user_id}/tags`** body shape **unchanged** (`subject_groups: List[str]` still works) — but now rejects entries whose Tag row has `parent_subject_group=NULL` (i.e. group-level rows are not user-selectable).

## Additive only

No legacy endpoints, fields, or rows removed. Old `interests` / `professions` tables and `mentor_experiences(WHAT_I_OFFER)` paths untouched. #233 cleanup still owns the eventual removals.

## Catalog seed deferred

Per the agreed plan, the SQL to populate `tags` rows from the X-Talent doc (industry / position / skill / topic trees, ~246 INSERTs across zh_TW + en_US) is delivered separately as a one-off ops script — **not committed to this repo**.

## Test plan

- [ ] `cd X-Talent-infra && docker compose up -d --build` — service boots
- [ ] Manually `ALTER TABLE` to add `parent_subject_group` on dev DB
- [ ] Insert a couple of (group, leaf) rows for kind=skill via psql
- [ ] `curl /user-service/api/v1/users/zh_TW/tags/catalog?kind=skill` → nested groups+leaves
- [ ] `curl -X PUT /user-service/api/v1/users/1/tags -d '{"kind":"skill","intent":"WANT","subject_groups":["frontend_dev"]}'` → 200
- [ ] `curl /user-service/api/v1/users/1/tags?intent=WANT` → entry has `parent_subject_group: "software_dev"`
- [ ] `curl -X PUT /user-service/api/v1/users/1/tags -d '{"kind":"skill","intent":"WANT","subject_groups":["software_dev"]}'` → 4xx (group-level rejected)
- [ ] `curl /user-service/api/v1/mentors/1/zh_TW/mentor_profile` → response carries `user_tags` array

Refs Xchange-Taiwan/X-Talent-Tracker#226

Generated with [Claude Code](https://claude.com/claude-code)
