### PR TITLE
feat(reservation): expose job_title and company for both sides in ReservationVO

### DIFF
--- a/src/domain/user/dao/reservation_repository.py
+++ b/src/domain/user/dao/reservation_repository.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Dict
 from sqlalchemy import func, Integer, Select, select, update, insert, join, and_, bindparam, exists
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 from src.config.conf import BATCH, RESERVATION_ISOLAION_LEVEL
 from src.domain.user.model.reservation_model import *
 from src.infra.db.orm.init.user_init import *
@@ -237,6 +238,7 @@ class ReservationRepository:
     async def get_user_reservations(self, db: AsyncSession,
                                     user_id: int,
                                     query: ReservationQueryDTO) -> Optional[List[ReservationDTO]]:
+        SenderProfile = aliased(Profile)
         stmt = select(
             Reservation.id,
             Reservation.schedule_id,
@@ -252,14 +254,21 @@ class ReservationRepository:
             Profile.name,
             Profile.avatar,
             Profile.job_title,
+            Profile.company,
             Profile.years_of_experience,
+            SenderProfile.name.label('sender_name'),
+            SenderProfile.avatar.label('sender_avatar'),
+            SenderProfile.job_title.label('sender_job_title'),
+            SenderProfile.company.label('sender_company'),
+            SenderProfile.years_of_experience.label('sender_years_of_experience'),
         ).select_from(
-            join(
-                Reservation,
-                Profile,
-                Reservation.user_id == Profile.user_id,
-                isouter=True,
-            )
+            Reservation
+        ).outerjoin(
+            Profile,
+            Reservation.user_id == Profile.user_id,
+        ).outerjoin(
+            SenderProfile,
+            Reservation.my_user_id == SenderProfile.user_id,
         )
         # for key, value in query.items():
         #     stmt = stmt.where(getattr(Reservation, key) == value)

--- a/src/domain/user/model/reservation_model.py
+++ b/src/domain/user/model/reservation_model.py
@@ -147,6 +147,7 @@ class RUserInfoVO(BaseModel):
     name: Optional[str] = ''
     avatar: Optional[str] = ''
     job_title: Optional[str] = ''
+    company: Optional[str] = ''
     years_of_experience: Optional[str] = '0'
 
 
@@ -243,6 +244,11 @@ class ReservationInfoVO(BaseModel):
                 user_id=reservation.my_user_id,
                 role=sender_role.value if sender_role else None,
                 status=reservation.my_status,
+                name=reservation.sender_name,
+                avatar=reservation.sender_avatar,
+                job_title=reservation.sender_job_title,
+                company=reservation.sender_company,
+                years_of_experience=reservation.sender_years_of_experience,
             ),
             participant=RUserInfoVO(
                 user_id=reservation.user_id,
@@ -251,6 +257,7 @@ class ReservationInfoVO(BaseModel):
                 name=reservation.name,
                 avatar=reservation.avatar,
                 job_title=reservation.job_title,
+                company=reservation.company,
                 years_of_experience=reservation.years_of_experience,
             ),
             schedule_id=reservation.schedule_id,


### PR DESCRIPTION
## Summary
- Add `company` field to `RUserInfoVO`.
- Alias `Profile` twice in `get_user_reservations` so the sender side is also populated (previously only participant got profile fields).
- `ReservationInfoVO.from_sender_model` now fills `name`, `avatar`, `job_title`, `company`, `years_of_experience` for both sender and participant.

Frontend & DB schema unchanged — `Profile.company` already exists.

## Test plan
- [ ] `docker compose up` and call `GET /reservations` for a mentor/mentee with populated profile; verify both `sender` and `participant` carry `job_title` and `company`.
- [ ] Verify list still works when one side has no Profile row (outer joins should leave fields empty, not error).