### PR TITLE
feat(#226): drop user_tags, store mentor tags as profile arrays

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.serverless/
+.vscode/
+.idea/
+node_modules/
+.git/
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 8010
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8010", "--reload"]

--- a/src/app/_di/injection.py
+++ b/src/app/_di/injection.py
@@ -16,6 +16,7 @@ from src.domain.mentor.service.notify_service import NotifyService
 from src.domain.user.dao.mentor_experience_repository import MentorExperienceRepository
 from src.domain.user.dao.profile_repository import ProfileRepository
 from src.domain.user.dao.reservation_repository import ReservationRepository
+from src.domain.user.dao.tag_repository import TagRepository
 from src.domain.user.service.delete_account_service import DeleteAccountService
 from src.domain.user.dao.activity_repository import ActivityRepository
 from src.domain.user.service.reservation_service import ReservationService
@@ -23,6 +24,7 @@ from src.domain.user.service.activity_service import ActivityService
 from src.domain.user.service.interest_service import InterestService
 from src.domain.user.service.profession_service import ProfessionService
 from src.domain.user.service.profile_service import ProfileService
+from src.domain.user.service.tag_service import TagService
 from src.app.account.delete import DeleteAccount
 from src.app.reservation.booking import Booking
 from src.app.mentor_profile.upsert import MentorProfile
@@ -67,6 +69,16 @@ def get_reservation_dao() -> ReservationRepository:
 
 def get_activity_dao() -> ActivityRepository:
     return ActivityRepository()
+
+
+def get_tag_dao() -> TagRepository:
+    return TagRepository()
+
+
+def get_tag_service(
+    tag_repository: TagRepository = Depends(get_tag_dao),
+) -> TagService:
+    return TagService(tag_repository)
 
 
 def get_service_api() -> IServiceApi:
@@ -118,6 +130,7 @@ def get_mentor_service(
     interest_service: InterestService = Depends(get_interest_service),
     profession_service: ProfessionService = Depends(get_profession_service),
     profile_service: ProfileService = Depends(get_profile_service),
+    tag_service: TagService = Depends(get_tag_service),
 ) -> MentorService:
     return MentorService(
         mentor_repository,
@@ -125,6 +138,7 @@ def get_mentor_service(
         interest_service,
         profession_service,
         profile_service,
+        tag_service,
     )
 
 

--- a/src/config/constant.py
+++ b/src/config/constant.py
@@ -75,3 +75,13 @@ class SortingBy(Enum):
 class Sorting(Enum):
     ASC = 1
     DESC = -1
+
+
+class TagKind(Enum):
+    # The 5 mentor profile buckets are (kind × array): want_tags carries
+    # position/skill/topic; have_tags carries skill/topic. Intent is
+    # implicit in *which* array a subject_group lives in — no separate
+    # enum needed.
+    SKILL = 'skill'
+    POSITION = 'position'
+    TOPIC = 'topic'

--- a/src/domain/mentor/dao/mentor_repository.py
+++ b/src/domain/mentor/dao/mentor_repository.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional, Tuple
 
 from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -8,53 +8,69 @@ from src.infra.db.orm.init.user_init import Profile, MentorExperience
 from src.infra.util.convert_util import get_first_template
 
 
-# Input-only fields on MentorProfileDTO — they're per-bucket replace inputs,
-# not Profile columns. Service layer aggregates them into want_tags/have_tags
-# (which ARE columns) before this repository runs the upsert.
+# Per-bucket replace inputs on MentorProfileDTO — they're not Profile columns,
+# so they're stripped from the dump before the dto is mapped onto the ORM.
 _INPUT_BUCKET_FIELDS = {
     'want_position', 'want_skill', 'want_topic', 'have_skill', 'have_topic',
 }
 
 
+# (dto, want_tags, have_tags) — the storage arrays travel alongside the dto
+# rather than on it, so the API-facing dto stays free of plumbing fields.
+ProfileWithTags = Tuple[MentorProfileDTO, List[str], List[str]]
+
+
 class MentorRepository:
 
-    async def get_mentor_profile_by_id(self, db: AsyncSession, mentor_id: int) -> Optional[MentorProfileDTO]:
+    async def get_mentor_profile_by_id(
+        self, db: AsyncSession, mentor_id: int
+    ) -> Optional[ProfileWithTags]:
         stmt: Select = select(Profile).filter(Profile.user_id == mentor_id)
         mentor: Optional[Profile] = await get_first_template(db, stmt)
         if mentor is None:
             return None
-        return MentorProfileDTO.model_validate(mentor)
+        return self._split(mentor)
 
     async def find_profile_by_user_id(
         self, db: AsyncSession, user_id: int
-    ) -> Optional[MentorProfileDTO]:
+    ) -> Optional[ProfileWithTags]:
         # Used by the upsert path to pull existing want_tags/have_tags before
         # the per-bucket merge; returns None on first-time mentors.
         stmt: Select = select(Profile).filter(Profile.user_id == user_id)
         profile: Optional[Profile] = await get_first_template(db, stmt)
         if profile is None:
             return None
-        return MentorProfileDTO.model_validate(profile)
+        return self._split(profile)
 
-    async def upsert_mentor(self, db: AsyncSession, mentor_profile_dto: MentorProfileDTO) -> MentorProfileDTO:
+    async def upsert_mentor(
+        self,
+        db: AsyncSession,
+        mentor_profile_dto: MentorProfileDTO,
+        *,
+        want_tags: List[str],
+        have_tags: List[str],
+    ) -> ProfileWithTags:
         # Load-or-create rather than db.merge: the input bucket fields aren't
-        # Profile columns, and merge would clobber columns that the dto
-        # doesn't carry (e.g. want_tags on a body whose service layer is
-        # still warming up).
+        # Profile columns, and merge would clobber want_tags/have_tags
+        # columns the dto doesn't carry. The merged storage arrays come in
+        # as kwargs because they're storage state, not API surface.
         payload = mentor_profile_dto.model_dump(exclude=_INPUT_BUCKET_FIELDS)
+        payload['want_tags'] = want_tags
+        payload['have_tags'] = have_tags
+
         existing: Optional[Profile] = await db.get(Profile, mentor_profile_dto.user_id)
         if existing is None:
             model = Profile(**payload)
             db.add(model)
             await db.commit()
             await db.refresh(model)
-            return MentorProfileDTO.model_validate(model)
+            return self._split(model)
 
         for key, value in payload.items():
             setattr(existing, key, value)
         await db.commit()
         await db.refresh(existing)
-        return MentorProfileDTO.model_validate(existing)
+        return self._split(existing)
 
     async def delete_mentor_profile_by_id_and_language(self, db: AsyncSession, user_id: int, language: str) -> None:
         stmt: Select = select(Profile).join(MentorExperience, MentorExperience.user_id == Profile.user_id)
@@ -64,3 +80,11 @@ class MentorRepository:
         if mentor:
             await db.delete(mentor)
             await db.commit()
+
+    @staticmethod
+    def _split(profile: Profile) -> ProfileWithTags:
+        return (
+            MentorProfileDTO.model_validate(profile),
+            list(profile.want_tags or []),
+            list(profile.have_tags or []),
+        )

--- a/src/domain/mentor/dao/mentor_repository.py
+++ b/src/domain/mentor/dao/mentor_repository.py
@@ -1,32 +1,60 @@
-from typing import List
+from typing import Optional
 
-from sqlalchemy import func, Integer, Select, select
+from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.domain.mentor.model.mentor_model import MentorProfileDTO
 from src.infra.db.orm.init.user_init import Profile, MentorExperience
-from src.infra.util.convert_util import (
-    get_first_template,
-    get_all_template,
-    convert_dto_to_model,
-)
+from src.infra.util.convert_util import get_first_template
+
+
+# Input-only fields on MentorProfileDTO — they're per-bucket replace inputs,
+# not Profile columns. Service layer aggregates them into want_tags/have_tags
+# (which ARE columns) before this repository runs the upsert.
+_INPUT_BUCKET_FIELDS = {
+    'want_position', 'want_skill', 'want_topic', 'have_skill', 'have_topic',
+}
 
 
 class MentorRepository:
 
-    async def get_mentor_profile_by_id(self, db: AsyncSession, mentor_id: int) -> MentorProfileDTO:
+    async def get_mentor_profile_by_id(self, db: AsyncSession, mentor_id: int) -> Optional[MentorProfileDTO]:
         stmt: Select = select(Profile).filter(Profile.user_id == mentor_id)
-        mentor: Profile = await get_first_template(db, stmt)
-        # join MentorExperience 有存在的才返回
+        mentor: Optional[Profile] = await get_first_template(db, stmt)
+        if mentor is None:
+            return None
         return MentorProfileDTO.model_validate(mentor)
 
-    async def upsert_mentor(self, db: AsyncSession, mentor_profile_dto: MentorProfileDTO) -> MentorProfileDTO:
-        model: Profile = convert_dto_to_model(mentor_profile_dto, Profile)
+    async def find_profile_by_user_id(
+        self, db: AsyncSession, user_id: int
+    ) -> Optional[MentorProfileDTO]:
+        # Used by the upsert path to pull existing want_tags/have_tags before
+        # the per-bucket merge; returns None on first-time mentors.
+        stmt: Select = select(Profile).filter(Profile.user_id == user_id)
+        profile: Optional[Profile] = await get_first_template(db, stmt)
+        if profile is None:
+            return None
+        return MentorProfileDTO.model_validate(profile)
 
-        model = await db.merge(model)
-        res: MentorProfileDTO = MentorProfileDTO.model_validate(model)
+    async def upsert_mentor(self, db: AsyncSession, mentor_profile_dto: MentorProfileDTO) -> MentorProfileDTO:
+        # Load-or-create rather than db.merge: the input bucket fields aren't
+        # Profile columns, and merge would clobber columns that the dto
+        # doesn't carry (e.g. want_tags on a body whose service layer is
+        # still warming up).
+        payload = mentor_profile_dto.model_dump(exclude=_INPUT_BUCKET_FIELDS)
+        existing: Optional[Profile] = await db.get(Profile, mentor_profile_dto.user_id)
+        if existing is None:
+            model = Profile(**payload)
+            db.add(model)
+            await db.commit()
+            await db.refresh(model)
+            return MentorProfileDTO.model_validate(model)
+
+        for key, value in payload.items():
+            setattr(existing, key, value)
         await db.commit()
-        return res
+        await db.refresh(existing)
+        return MentorProfileDTO.model_validate(existing)
 
     async def delete_mentor_profile_by_id_and_language(self, db: AsyncSession, user_id: int, language: str) -> None:
         stmt: Select = select(Profile).join(MentorExperience, MentorExperience.user_id == Profile.user_id)

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from fastapi.encoders import jsonable_encoder
 from ...user.model.common_model import ProfessionListVO
+from ...user.model.tag_model import TagVO
 from ...user.model.user_model import *
 from .experience_model import ExperienceVO
 from ....config.conf import *
@@ -38,6 +39,22 @@ class MentorProfileDTO(ProfileDTO):
     seniority_level: Optional[SeniorityLevel] = None
     expertises: Optional[List[str]] = None
 
+    # Input buckets — leaf subject_groups grouped by (intent, kind). Per
+    # bucket: None = leave that bucket alone, [] = clear, [...] = replace.
+    # Server validates leaves against the tags catalog and merges with
+    # untouched buckets to produce want_tags/have_tags below.
+    want_position: Optional[List[str]] = None
+    want_skill: Optional[List[str]] = None
+    want_topic: Optional[List[str]] = None
+    have_skill: Optional[List[str]] = None
+    have_topic: Optional[List[str]] = None
+
+    # Mirrors profiles.want_tags / have_tags — server-computed from the
+    # buckets above before persistence; round-trips through model_validate
+    # so the GET path can read them back from the ORM row.
+    want_tags: Optional[List[str]] = None
+    have_tags: Optional[List[str]] = None
+
     class Config:
         from_attributes = True # orm_mode = True
 
@@ -62,6 +79,15 @@ class MentorProfileVO(ProfileVO):
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
     expertises: Optional[ProfessionListVO] = None
     experiences: Optional[List[ExperienceVO]] = Field(default_factory=list)
+
+    # Hydrated tag buckets — each element is a full TagVO joined from the
+    # catalog (subject, desc, parent_subject_group, etc.). None = not yet
+    # hydrated; [] = no tags in that bucket.
+    want_position: Optional[List[TagVO]] = None
+    want_skill: Optional[List[TagVO]] = None
+    want_topic: Optional[List[TagVO]] = None
+    have_skill: Optional[List[TagVO]] = None
+    have_topic: Optional[List[TagVO]] = None
 
     @staticmethod
     def of(mentor_profile_dto: MentorProfileDTO) -> 'MentorProfileVO':
@@ -103,10 +129,26 @@ class MentorProfileVO(ProfileVO):
         )
 
     def to_dto_json(self):
+        # Search consumes flat subject_group arrays per bucket — no need to
+        # ship the full TagVO over SQS, the Search side only filters on the
+        # canonical key.
         dto = self.from_dto()
         dto_dict = jsonable_encoder(dto)
-        dto_dict.update({'experiences': jsonable_encoder(self.experiences)})
+        dto_dict.update({
+            'experiences': jsonable_encoder(self.experiences),
+            'want_position': self._tag_subject_groups(self.want_position),
+            'want_skill': self._tag_subject_groups(self.want_skill),
+            'want_topic': self._tag_subject_groups(self.want_topic),
+            'have_skill': self._tag_subject_groups(self.have_skill),
+            'have_topic': self._tag_subject_groups(self.have_topic),
+        })
         return dto_dict
+
+    @staticmethod
+    def _tag_subject_groups(tags: Optional[List[TagVO]]) -> List[str]:
+        if not tags:
+            return []
+        return [t.subject_group for t in tags if t.subject_group]
 
 
 class TimeSlotDTO(BaseModel):

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -42,18 +42,14 @@ class MentorProfileDTO(ProfileDTO):
     # Input buckets — leaf subject_groups grouped by (intent, kind). Per
     # bucket: None = leave that bucket alone, [] = clear, [...] = replace.
     # Server validates leaves against the tags catalog and merges with
-    # untouched buckets to produce want_tags/have_tags below.
+    # the existing storage arrays to produce profiles.want_tags / have_tags
+    # — those columns intentionally never appear on this dto so the API
+    # contract stays small.
     want_position: Optional[List[str]] = None
     want_skill: Optional[List[str]] = None
     want_topic: Optional[List[str]] = None
     have_skill: Optional[List[str]] = None
     have_topic: Optional[List[str]] = None
-
-    # Mirrors profiles.want_tags / have_tags — server-computed from the
-    # buckets above before persistence; round-trips through model_validate
-    # so the GET path can read them back from the ORM row.
-    want_tags: Optional[List[str]] = None
-    have_tags: Optional[List[str]] = None
 
     class Config:
         from_attributes = True # orm_mode = True

--- a/src/domain/mentor/service/mentor_service.py
+++ b/src/domain/mentor/service/mentor_service.py
@@ -1,9 +1,9 @@
-from typing import Optional
+from typing import List
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config.conf import DEFAULT_LANGUAGE
-from src.config.exception import NotFoundException, ServerException, raise_http_exception
+from src.config.exception import NotFoundException, raise_http_exception
 from src.domain.mentor.dao.mentor_repository import MentorRepository
 from src.domain.mentor.model.mentor_model import MentorProfileDTO, MentorProfileVO
 from src.domain.user.dao.profile_repository import ProfileRepository
@@ -30,14 +30,16 @@ class MentorService:
         try:
             language = profile_dto.language or DEFAULT_LANGUAGE
 
-            # Read existing arrays first so untouched buckets survive the
+            # Pull existing arrays first so untouched buckets survive the
             # per-bucket replace semantics (None = leave alone, [] = clear).
             # First-time mentors won't have a row yet — fall back to empty.
             existing = await self.__mentor_repository.find_profile_by_user_id(
                 db, profile_dto.user_id,
             )
-            existing_want = list(existing.want_tags or []) if existing else []
-            existing_have = list(existing.have_tags or []) if existing else []
+            if existing is None:
+                existing_want, existing_have = [], []
+            else:
+                _, existing_want, existing_have = existing
 
             new_want, new_have = await self.__tag_service.merge_buckets_to_arrays(
                 db,
@@ -50,34 +52,35 @@ class MentorService:
                 have_skill=profile_dto.have_skill,
                 have_topic=profile_dto.have_topic,
             )
-            # Stamp the merged arrays back onto the dto so the upsert's
-            # convert_dto_to_model picks them up — Profile.want_tags/have_tags
-            # are 1:1 columns, the 5 input buckets aren't.
-            profile_dto.want_tags = new_want
-            profile_dto.have_tags = new_have
 
-            res_dto: MentorProfileDTO = await self.__mentor_repository.upsert_mentor(db, profile_dto)
+            # Storage arrays travel as kwargs — they're state, not API.
+            res_dto, res_want, res_have = await self.__mentor_repository.upsert_mentor(
+                db, profile_dto, want_tags=new_want, have_tags=new_have,
+            )
 
             res_vo: MentorProfileVO = await self.__profile_service.convert_to_mentor_profile_vo(
                 db, res_dto, language=language,
             )
-            await self.__hydrate_buckets(db, res_vo, res_dto, language)
+            await self.__hydrate_buckets(db, res_vo, res_want, res_have, language)
             return res_vo
         except Exception as e:
             log.error(f'upsert_mentor_profile error: %s', str(e))
             err_msg = getattr(e, 'msg', 'upsert mentor profile response failed')
-            raise ServerException(msg=err_msg)
+            # raise_http_exception preserves ClientException as 400; other
+            # failures still surface as 500 via ServerException.
+            raise_http_exception(e, msg=err_msg)
 
     async def get_mentor_profile_by_id(self, db: AsyncSession, user_id: int, language: str) \
             -> MentorProfileVO:
         try:
-            mentor_dto: MentorProfileDTO = await self.__mentor_repository.get_mentor_profile_by_id(db, user_id)
-            if mentor_dto is None:
+            row = await self.__mentor_repository.get_mentor_profile_by_id(db, user_id)
+            if row is None:
                 raise NotFoundException(msg=f"No such user with id: {user_id}")
+            mentor_dto, want_tags, have_tags = row
             res_vo: MentorProfileVO = await self.__profile_service.convert_to_mentor_profile_vo(
                 db, mentor_dto, language=language,
             )
-            await self.__hydrate_buckets(db, res_vo, mentor_dto, language)
+            await self.__hydrate_buckets(db, res_vo, want_tags, have_tags, language)
             return res_vo
         except Exception as e:
             log.error(f'get_mentor_profile_by_id error: %s', str(e))
@@ -88,7 +91,8 @@ class MentorService:
         self,
         db: AsyncSession,
         vo: MentorProfileVO,
-        dto: MentorProfileDTO,
+        want_tags: List[str],
+        have_tags: List[str],
         language: str,
     ) -> None:
         # Best-effort: hydration failure shouldn't fail the whole profile read.
@@ -97,12 +101,12 @@ class MentorService:
         try:
             buckets = await self.__tag_service.hydrate_buckets(
                 db,
-                want_tags=list(dto.want_tags or []),
-                have_tags=list(dto.have_tags or []),
+                want_tags=want_tags,
+                have_tags=have_tags,
                 language=language,
             )
         except Exception as e:
-            log.warning("hydrate buckets failed for user %s: %s", dto.user_id, e)
+            log.warning("hydrate buckets failed for user %s: %s", vo.user_id, e)
             buckets = {
                 'want_position': [], 'want_skill': [], 'want_topic': [],
                 'have_skill': [], 'have_topic': [],

--- a/src/domain/mentor/service/mentor_service.py
+++ b/src/domain/mentor/service/mentor_service.py
@@ -1,5 +1,8 @@
+from typing import Optional
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.config.conf import DEFAULT_LANGUAGE
 from src.config.exception import NotFoundException, ServerException, raise_http_exception
 from src.domain.mentor.dao.mentor_repository import MentorRepository
 from src.domain.mentor.model.mentor_model import MentorProfileDTO, MentorProfileVO
@@ -7,23 +10,58 @@ from src.domain.user.dao.profile_repository import ProfileRepository
 from src.domain.user.service.interest_service import InterestService
 from src.domain.user.service.profession_service import ProfessionService
 from src.domain.user.service.profile_service import ProfileService
+from src.domain.user.service.tag_service import TagService
 import logging
 
 log = logging.getLogger(__name__)
 
 class MentorService:
     def __init__(self, mentor_repository: MentorRepository, profile_repository: ProfileRepository,
-                 interest_service: InterestService, profession_service: ProfessionService, profile_service: ProfileService):
+                 interest_service: InterestService, profession_service: ProfessionService,
+                 profile_service: ProfileService, tag_service: TagService):
         self.__mentor_repository: MentorRepository = mentor_repository
         self.__interest_service: InterestService = interest_service
         self.__profession_service: ProfessionService = profession_service
         self.__profile_repository: ProfileRepository = profile_repository
         self.__profile_service: ProfileService = profile_service
+        self.__tag_service: TagService = tag_service
 
     async def upsert_mentor_profile(self, db: AsyncSession, profile_dto: MentorProfileDTO) -> MentorProfileVO:
         try:
+            language = profile_dto.language or DEFAULT_LANGUAGE
+
+            # Read existing arrays first so untouched buckets survive the
+            # per-bucket replace semantics (None = leave alone, [] = clear).
+            # First-time mentors won't have a row yet — fall back to empty.
+            existing = await self.__mentor_repository.find_profile_by_user_id(
+                db, profile_dto.user_id,
+            )
+            existing_want = list(existing.want_tags or []) if existing else []
+            existing_have = list(existing.have_tags or []) if existing else []
+
+            new_want, new_have = await self.__tag_service.merge_buckets_to_arrays(
+                db,
+                current_want_tags=existing_want,
+                current_have_tags=existing_have,
+                language=language,
+                want_position=profile_dto.want_position,
+                want_skill=profile_dto.want_skill,
+                want_topic=profile_dto.want_topic,
+                have_skill=profile_dto.have_skill,
+                have_topic=profile_dto.have_topic,
+            )
+            # Stamp the merged arrays back onto the dto so the upsert's
+            # convert_dto_to_model picks them up — Profile.want_tags/have_tags
+            # are 1:1 columns, the 5 input buckets aren't.
+            profile_dto.want_tags = new_want
+            profile_dto.have_tags = new_have
+
             res_dto: MentorProfileDTO = await self.__mentor_repository.upsert_mentor(db, profile_dto)
-            res_vo: MentorProfileVO = await self.__profile_service.convert_to_mentor_profile_vo(db, res_dto, language=profile_dto.language)
+
+            res_vo: MentorProfileVO = await self.__profile_service.convert_to_mentor_profile_vo(
+                db, res_dto, language=language,
+            )
+            await self.__hydrate_buckets(db, res_vo, res_dto, language)
             return res_vo
         except Exception as e:
             log.error(f'upsert_mentor_profile error: %s', str(e))
@@ -36,8 +74,41 @@ class MentorService:
             mentor_dto: MentorProfileDTO = await self.__mentor_repository.get_mentor_profile_by_id(db, user_id)
             if mentor_dto is None:
                 raise NotFoundException(msg=f"No such user with id: {user_id}")
-            return await self.__profile_service.convert_to_mentor_profile_vo(db, mentor_dto, language=language)
+            res_vo: MentorProfileVO = await self.__profile_service.convert_to_mentor_profile_vo(
+                db, mentor_dto, language=language,
+            )
+            await self.__hydrate_buckets(db, res_vo, mentor_dto, language)
+            return res_vo
         except Exception as e:
             log.error(f'get_mentor_profile_by_id error: %s', str(e))
             err_msg = getattr(e, 'msg', 'get mentor profile response failed')
             raise_http_exception(e, msg=err_msg)
+
+    async def __hydrate_buckets(
+        self,
+        db: AsyncSession,
+        vo: MentorProfileVO,
+        dto: MentorProfileDTO,
+        language: str,
+    ) -> None:
+        # Best-effort: hydration failure shouldn't fail the whole profile read.
+        # Empty buckets ([]) are explicit on the wire so the frontend can
+        # distinguish "user has none" from "field absent".
+        try:
+            buckets = await self.__tag_service.hydrate_buckets(
+                db,
+                want_tags=list(dto.want_tags or []),
+                have_tags=list(dto.have_tags or []),
+                language=language,
+            )
+        except Exception as e:
+            log.warning("hydrate buckets failed for user %s: %s", dto.user_id, e)
+            buckets = {
+                'want_position': [], 'want_skill': [], 'want_topic': [],
+                'have_skill': [], 'have_topic': [],
+            }
+        vo.want_position = buckets['want_position']
+        vo.want_skill = buckets['want_skill']
+        vo.want_topic = buckets['want_topic']
+        vo.have_skill = buckets['have_skill']
+        vo.have_topic = buckets['have_topic']

--- a/src/domain/mentor/service/notify_service.py
+++ b/src/domain/mentor/service/notify_service.py
@@ -1,19 +1,12 @@
 from typing import List, Optional
-from fastapi import BackgroundTasks
-from fastapi.encoders import jsonable_encoder
-from sqlalchemy.ext.asyncio import AsyncSession
-from src.infra.template.service_api import IServiceApi
 from src.infra.mq.sqs_mq_adapter import SqsMqAdapter
 from src.infra.databse import SessionLocal
-from src.domain.user.service.profile_service import ProfileService
-from src.domain.user.model import user_model as user
 from src.domain.mentor.service.mentor_service import MentorService
 from src.domain.mentor.service.experience_service import ExperienceService
 from src.domain.mentor.model import (
     experience_model as exp,
     mentor_model as mentor,
 )
-from src.config.constant import ExperienceCategory
 from src.config.conf import (
     SEARCH_SERVICE_URL,
     DEFAULT_LANGUAGE,
@@ -46,6 +39,9 @@ class NotifyService:
                         db, user_id, DEFAULT_LANGUAGE
                     )
                 )
+            # to_dto_json flattens the 5 hydrated tag buckets into top-level
+            # subject_group arrays — Search filters by canonical key, so the
+            # full TagVO would be wasted bytes on the wire.
             payload = {
                 **mentor_profile.to_dto_json(),
                 "action": "UPSERT_MENTOR_PROFILE",

--- a/src/domain/user/dao/profile_repository.py
+++ b/src/domain/user/dao/profile_repository.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.config.exception import NotFoundException
 from src.domain.user.model.user_model import ProfileDTO
 from src.infra.db.orm.init.user_init import Profile
-from src.infra.util.convert_util import convert_dto_to_model, get_first_template
+from src.infra.util.convert_util import get_first_template
 
 
 class ProfileRepository:
@@ -29,16 +29,25 @@ class ProfileRepository:
     async def upsert_profile(self, db: AsyncSession, dto: ProfileDTO) -> ProfileDTO:
         if (dto is None) or (dto.user_id is None):
             raise NotFoundException(msg="not a valid user")
-        # directly upsert since the user_id should be pre dedined in auth service
 
-        model: Profile = convert_dto_to_model(dto, Profile)
-        model = await db.merge(model)
+        # Load-or-create instead of db.merge — ProfileDTO no longer covers
+        # every Profile column (mentor-only want_tags/have_tags live on the
+        # row but not the mentee dto), and merge would copy unset attrs as
+        # NULL, clobbering existing tag arrays.
+        existing: Optional[Profile] = await db.get(Profile, dto.user_id)
+        if existing is None:
+            model = Profile(**dto.model_dump())
+            db.add(model)
+            await db.commit()
+            await db.refresh(model)
+            return ProfileDTO.model_validate(model)
 
+        for key, value in dto.model_dump().items():
+            setattr(existing, key, value)
         await db.commit()
-        await db.refresh(model)
-        return ProfileDTO.model_validate(model)
+        await db.refresh(existing)
+        return ProfileDTO.model_validate(existing)
 
     async def delete_profile(self, db: AsyncSession, user_id: int) -> None:
         stmt = sa_delete(Profile).where(Profile.user_id == user_id)
         await db.execute(stmt)
-

--- a/src/domain/user/dao/tag_repository.py
+++ b/src/domain/user/dao/tag_repository.py
@@ -1,0 +1,90 @@
+from typing import List, Optional, Type
+
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config.constant import TagKind
+from src.infra.db.orm.init.user_init import Tag
+from src.infra.util.convert_util import get_all_template, get_first_template
+
+
+class TagRepository:
+    async def get_tag_by_id(
+        self, db: AsyncSession, tag_id: int
+    ) -> Optional[Type[Tag]]:
+        stmt: Select = select(Tag).filter(Tag.id == tag_id)
+        return await get_first_template(db, stmt)
+
+    async def get_tags_by_ids(
+        self, db: AsyncSession, ids: List[int]
+    ) -> List[Type[Tag]]:
+        if not ids:
+            return []
+        stmt: Select = select(Tag).filter(Tag.id.in_(ids))
+        return await get_all_template(db, stmt)
+
+    async def get_tags_by_kind(
+        self,
+        db: AsyncSession,
+        kind: TagKind,
+        language: Optional[str] = None,
+    ) -> List[Type[Tag]]:
+        stmt: Select = select(Tag).filter(Tag.kind == kind.value)
+        if language is not None:
+            stmt = stmt.filter(Tag.language == language)
+        return await get_all_template(db, stmt)
+
+    async def list_catalog(
+        self,
+        db: AsyncSession,
+        kind: TagKind,
+        language: str,
+    ) -> List[Type[Tag]]:
+        # Returns both group and leaf rows; service layer nests them.
+        stmt: Select = (
+            select(Tag)
+            .filter(Tag.kind == kind.value)
+            .filter(Tag.language == language)
+            .order_by(Tag.parent_subject_group.nullsfirst(), Tag.subject_group)
+        )
+        return await get_all_template(db, stmt)
+
+    async def find_tag(
+        self,
+        db: AsyncSession,
+        kind: str,
+        subject_group: str,
+        language: str,
+    ) -> Optional[Type[Tag]]:
+        # When multiple subjects share a (kind, subject_group, language),
+        # take the first — legacy writes only carried subject_group.
+        stmt: Select = (
+            select(Tag)
+            .filter(Tag.kind == kind)
+            .filter(Tag.subject_group == subject_group)
+            .filter(Tag.language == language)
+            .order_by(Tag.id)
+            .limit(1)
+        )
+        return await get_first_template(db, stmt)
+
+    async def find_leaves_by_subject_groups(
+        self,
+        db: AsyncSession,
+        subject_groups: List[str],
+        language: str,
+    ) -> List[Type[Tag]]:
+        # Bulk lookup for hydrating profile.want_tags/have_tags arrays at GET
+        # time. parent_subject_group IS NOT NULL is the leaf marker — group
+        # rows are catalog scaffolding and never appear in user arrays under
+        # the strict-validation invariant.
+        if not subject_groups:
+            return []
+        stmt: Select = (
+            select(Tag)
+            .filter(Tag.subject_group.in_(subject_groups))
+            .filter(Tag.language == language)
+            .filter(Tag.parent_subject_group.is_not(None))
+            .order_by(Tag.id)
+        )
+        return await get_all_template(db, stmt)

--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class TagVO(BaseModel):
+    id: int
+    kind: str
+    subject_group: Optional[str] = None
+    language: Optional[str] = None
+    subject: Optional[str] = ''
+    # Free-form display metadata (icon, color, etc.).
+    desc: Optional[Dict[str, Any]] = None
+    # NULL on group rows (and on flat-kind rows like industry); non-NULL on
+    # leaves, pointing at the group's subject_group within the same kind.
+    parent_subject_group: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
+class TagCatalogLeafVO(BaseModel):
+    tag_id: int
+    subject_group: str
+    subject: str
+    language: str
+    desc: Optional[Dict[str, Any]] = None
+
+
+class TagCatalogGroupVO(BaseModel):
+    subject_group: str
+    subject: str
+    language: str
+    desc: Optional[Dict[str, Any]] = None
+    leaves: List[TagCatalogLeafVO] = []
+
+
+class TagCatalogVO(BaseModel):
+    kind: str
+    language: str
+    groups: List[TagCatalogGroupVO] = []
+
+
+class TagCatalogsVO(BaseModel):
+    """Catalog response keyed by kind, so callers index `catalogs[kind]`
+    uniformly whether they asked for one kind or all."""
+    language: str
+    catalogs: Dict[str, TagCatalogVO] = {}

--- a/src/domain/user/service/profile_service.py
+++ b/src/domain/user/service/profile_service.py
@@ -1,14 +1,12 @@
-import asyncio
 import logging
-from typing import Optional, Coroutine, Any, Set, Dict, List, Union
+from typing import Optional, Dict, List
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.config.constant import InterestCategory, ExperienceCategory
+from src.config.constant import InterestCategory
 from src.config.exception import (
     NotAcceptableException,
     NotFoundException,
-    ServerException,
     raise_http_exception,
 )
 from src.domain.mentor.model.mentor_model import MentorProfileDTO, MentorProfileVO
@@ -16,7 +14,6 @@ from src.domain.mentor.model.experience_model import ExperienceVO
 from src.domain.mentor.service.experience_service import ExperienceService
 from src.domain.user.dao.profile_repository import ProfileRepository
 from src.domain.user.model.common_model import (
-    ProfessionVO,
     InterestVO,
     InterestListVO,
     ProfessionListVO,

--- a/src/domain/user/service/tag_service.py
+++ b/src/domain/user/service/tag_service.py
@@ -1,0 +1,296 @@
+import logging
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config.constant import TagKind
+from src.config.exception import (
+    ClientException,
+    raise_http_exception,
+)
+from src.domain.user.dao.tag_repository import TagRepository
+from src.domain.user.model.tag_model import (
+    TagCatalogGroupVO,
+    TagCatalogLeafVO,
+    TagCatalogVO,
+    TagCatalogsVO,
+    TagVO,
+)
+
+log = logging.getLogger(__name__)
+
+
+# Two intent-side maps replace what was a (kind, intent) tuple lookup —
+# intent now means "which array (want_tags vs have_tags) the subject_group
+# is stored in", so it never needs to round-trip through an enum.
+# position/HAVE is intentionally absent — mentors offer skills/topics, not
+# positions.
+_WANT_BUCKET_BY_KIND: Dict[str, str] = {
+    TagKind.POSITION.value: 'want_position',
+    TagKind.SKILL.value:    'want_skill',
+    TagKind.TOPIC.value:    'want_topic',
+}
+_HAVE_BUCKET_BY_KIND: Dict[str, str] = {
+    TagKind.SKILL.value: 'have_skill',
+    TagKind.TOPIC.value: 'have_topic',
+}
+
+_WANT_BUCKETS = ('want_position', 'want_skill', 'want_topic')
+_HAVE_BUCKETS = ('have_skill', 'have_topic')
+
+_BUCKET_TO_KIND: Dict[str, TagKind] = {
+    'want_position': TagKind.POSITION,
+    'want_skill':    TagKind.SKILL,
+    'want_topic':    TagKind.TOPIC,
+    'have_skill':    TagKind.SKILL,
+    'have_topic':    TagKind.TOPIC,
+}
+
+
+class TagService:
+    def __init__(self, tag_repository: TagRepository):
+        self.__tag_repository: TagRepository = tag_repository
+
+    # ------------------------------------------------------------------
+    # Catalog
+    # ------------------------------------------------------------------
+    async def get_catalog(
+        self,
+        db: AsyncSession,
+        kind: TagKind,
+        language: str,
+    ) -> TagCatalogVO:
+        # Strict invariant: parent_subject_group IS NULL ⇔ group row;
+        # NOT NULL ⇔ leaf. _validate_leaves rejects writes that would
+        # break this, so orphan leaves can't accumulate.
+        try:
+            rows = await self.__tag_repository.list_catalog(db, kind, language)
+
+            groups_by_key: dict = {}
+            ordered_keys: List[str] = []
+
+            for tag in rows:
+                if tag.parent_subject_group is None:
+                    if tag.subject_group not in groups_by_key:
+                        groups_by_key[tag.subject_group] = TagCatalogGroupVO(
+                            subject_group=tag.subject_group,
+                            subject=tag.subject or '',
+                            language=tag.language,
+                            desc=tag.desc,
+                            leaves=[],
+                        )
+                        ordered_keys.append(tag.subject_group)
+                else:
+                    leaf = TagCatalogLeafVO(
+                        tag_id=tag.id,
+                        subject_group=tag.subject_group,
+                        subject=tag.subject or '',
+                        language=tag.language,
+                        desc=tag.desc,
+                    )
+                    parent = groups_by_key.get(tag.parent_subject_group)
+                    if parent is not None:
+                        parent.leaves.append(leaf)
+                    # Leaf whose parent isn't in this language gets dropped —
+                    # the catalog is mis-seeded and pretending otherwise hides
+                    # the bug.
+
+            return TagCatalogVO(
+                kind=kind.value,
+                language=language,
+                groups=[groups_by_key[k] for k in ordered_keys],
+            )
+        except Exception as e:
+            log.error("get_catalog error: %s", str(e))
+            raise_http_exception(e, msg="Internal Server Error")
+
+    async def get_catalogs(
+        self,
+        db: AsyncSession,
+        kinds: Optional[List[TagKind]],
+        language: str,
+    ) -> TagCatalogsVO:
+        # Sequential — AsyncSession isn't safe for concurrent ops on the
+        # same session, so gather() would race.
+        target_kinds = list(kinds) if kinds else list(TagKind)
+        catalogs: dict = {}
+        for k in target_kinds:
+            vo = await self.get_catalog(db, k, language)
+            catalogs[vo.kind] = vo
+        return TagCatalogsVO(language=language, catalogs=catalogs)
+
+    # ------------------------------------------------------------------
+    # Bucket merge (write path) and hydrate (read path)
+    # ------------------------------------------------------------------
+    async def merge_buckets_to_arrays(
+        self,
+        db: AsyncSession,
+        current_want_tags: List[str],
+        current_have_tags: List[str],
+        language: str,
+        *,
+        want_position: Optional[List[str]] = None,
+        want_skill: Optional[List[str]] = None,
+        want_topic: Optional[List[str]] = None,
+        have_skill: Optional[List[str]] = None,
+        have_topic: Optional[List[str]] = None,
+    ) -> Tuple[List[str], List[str]]:
+        # Per-bucket replace semantics: None = keep existing items of that
+        # (kind, intent) untouched, [] = clear that bucket, [...] = replace.
+        # Existing items whose kind we can't resolve from the catalog are
+        # preserved untouched (don't drop user data on lookup misses).
+        try:
+            inputs = {
+                'want_position': want_position,
+                'want_skill': want_skill,
+                'want_topic': want_topic,
+                'have_skill': have_skill,
+                'have_topic': have_topic,
+            }
+            replaced_buckets = {b for b, v in inputs.items() if v is not None}
+
+            existing_kind_by_sg = await self._lookup_kinds(
+                db, list(set(current_want_tags) | set(current_have_tags)), language
+            )
+
+            new_want = self._preserve_unreplaced(
+                current_want_tags, existing_kind_by_sg,
+                bucket_by_kind=_WANT_BUCKET_BY_KIND, replaced=replaced_buckets,
+            )
+            new_have = self._preserve_unreplaced(
+                current_have_tags, existing_kind_by_sg,
+                bucket_by_kind=_HAVE_BUCKET_BY_KIND, replaced=replaced_buckets,
+            )
+
+            for bucket in _WANT_BUCKETS:
+                if inputs[bucket] is not None:
+                    leaves = await self._validate_leaves(
+                        db, _BUCKET_TO_KIND[bucket], inputs[bucket], language,
+                    )
+                    new_want.extend(leaf.subject_group for leaf in leaves)
+
+            for bucket in _HAVE_BUCKETS:
+                if inputs[bucket] is not None:
+                    leaves = await self._validate_leaves(
+                        db, _BUCKET_TO_KIND[bucket], inputs[bucket], language,
+                    )
+                    new_have.extend(leaf.subject_group for leaf in leaves)
+
+            return _dedup(new_want), _dedup(new_have)
+        except ClientException:
+            raise
+        except Exception as e:
+            log.error("merge_buckets_to_arrays error: %s", str(e))
+            raise_http_exception(e, msg="Internal Server Error")
+
+    async def hydrate_buckets(
+        self,
+        db: AsyncSession,
+        want_tags: List[str],
+        have_tags: List[str],
+        language: str,
+    ) -> Dict[str, List[TagVO]]:
+        # Single bulk JOIN of all tagged subject_groups, then bucketed by
+        # (which-array, kind=catalog row). Items not found in the catalog
+        # drop out — they don't belong to any bucket.
+        result: Dict[str, List[TagVO]] = {
+            'want_position': [], 'want_skill': [], 'want_topic': [],
+            'have_skill': [], 'have_topic': [],
+        }
+        all_sgs = list(set(want_tags) | set(have_tags))
+        if not all_sgs:
+            return result
+
+        try:
+            rows = await self.__tag_repository.find_leaves_by_subject_groups(
+                db, all_sgs, language,
+            )
+            tag_by_sg: Dict[str, object] = {row.subject_group: row for row in rows}
+
+            for source, bucket_by_kind in (
+                (want_tags, _WANT_BUCKET_BY_KIND),
+                (have_tags, _HAVE_BUCKET_BY_KIND),
+            ):
+                for sg in source:
+                    tag = tag_by_sg.get(sg)
+                    if tag is None:
+                        continue
+                    bucket = bucket_by_kind.get(tag.kind)
+                    if bucket is None:
+                        # e.g. position written into have_tags somehow —
+                        # not a valid combination; skip rather than crash.
+                        continue
+                    result[bucket].append(TagVO.model_validate(tag))
+            return result
+        except Exception as e:
+            log.error("hydrate_buckets error: %s", str(e))
+            raise_http_exception(e, msg="Internal Server Error")
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    async def _validate_leaves(
+        self,
+        db: AsyncSession,
+        kind: TagKind,
+        subject_groups: List[str],
+        language: str,
+    ) -> List[object]:
+        # Strict: subject_groups must already exist as leaves in the catalog
+        # (parent_subject_group is set). Unknown rows or top-level groups
+        # are rejected so user writes can't drift the catalog.
+        leaves: List[object] = []
+        for sg in subject_groups:
+            tag = await self.__tag_repository.find_tag(db, kind.value, sg, language)
+            if tag is None:
+                raise ClientException(
+                    msg=(
+                        f"unknown subject_group '{sg}' for kind={kind.value}; "
+                        f"seed the catalog first."
+                    )
+                )
+            if tag.parent_subject_group is None:
+                raise ClientException(
+                    msg=(
+                        f"subject_group '{sg}' is a top-level group; "
+                        f"user selections must reference leaf tags."
+                    )
+                )
+            leaves.append(tag)
+        return leaves
+
+    async def _lookup_kinds(
+        self,
+        db: AsyncSession,
+        subject_groups: List[str],
+        language: str,
+    ) -> Dict[str, str]:
+        if not subject_groups:
+            return {}
+        rows = await self.__tag_repository.find_leaves_by_subject_groups(
+            db, subject_groups, language,
+        )
+        return {row.subject_group: row.kind for row in rows}
+
+    @staticmethod
+    def _preserve_unreplaced(
+        current: List[str],
+        kind_by_sg: Dict[str, str],
+        bucket_by_kind: Dict[str, str],
+        replaced: set,
+    ) -> List[str]:
+        kept: List[str] = []
+        for sg in current:
+            kind = kind_by_sg.get(sg)
+            bucket = bucket_by_kind.get(kind) if kind is not None else None
+            # Unresolvable items (no catalog match) stay put — don't lose
+            # user data on lookup misses.
+            if bucket is None or bucket not in replaced:
+                kept.append(sg)
+        return kept
+
+
+def _dedup(items: List[str]) -> List[str]:
+    # dict.fromkeys preserves first-seen order, which matters for the SQS
+    # payload + GET response staying stable across writes.
+    return list(dict.fromkeys(items))

--- a/src/infra/databse.py
+++ b/src/infra/databse.py
@@ -19,6 +19,11 @@ server_settings = {}
 if DB_JIT_OFF:
     server_settings["jit"] = "off"
 
+# Without this, unqualified table names hit `public` regardless of DB_SCHEMA.
+# No-op when DB_SCHEMA=public.
+if DB_SCHEMA:
+    server_settings["search_path"] = f'"{DB_SCHEMA}", public'
+
 # 資料庫引擎配置：使用配置參數設置連接池和超時
 engine = create_async_engine(
     DATABASE_URL, 

--- a/src/infra/db/orm/init/user_init.py
+++ b/src/infra/db/orm/init/user_init.py
@@ -2,7 +2,7 @@ from profile import Profile
 
 import sqlalchemy.dialects.postgresql
 from sqlalchemy import Integer, BigInteger, Column, String, Text, DateTime, Boolean, func
-from sqlalchemy.dialects.postgresql import JSONB, ENUM
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, ENUM
 from sqlalchemy.ext.declarative import declarative_base
 from typing_extensions import Optional
 
@@ -33,6 +33,11 @@ class Profile(Base):
     expertises = Column(JSONB)
     language = Column(String(10), default='')
     is_mentor = Column(Boolean, default=False)
+    # Mentor-side tag selections, stored as flat subject_group arrays. Kind
+    # comes from the tags catalog (a JOIN at read time buckets these into
+    # want_position / want_skill / want_topic / have_skill / have_topic).
+    want_tags = Column(ARRAY(String), nullable=False, server_default='{}')
+    have_tags = Column(ARRAY(String), nullable=False, server_default='{}')
 
 
 class MentorExperience(Base):
@@ -144,3 +149,17 @@ class Activity(Base):
             mentee_reservation_id={self.mentee_reservation_id}, \
             service={self.service}, \
             status={self.status})>'
+
+
+class Tag(Base):
+    __tablename__ = 'tags'
+    id = Column(BigInteger, primary_key=True)
+    kind = Column(String(20), nullable=False)
+    subject_group = Column(String(40))
+    language = Column(String(10))
+    subject = Column(Text, nullable=False, default='')
+    desc = Column(JSONB)
+    # parent_subject_group IS NULL ⇔ group row (catalog scaffolding);
+    # NOT NULL ⇔ leaf. _validate_leaves enforces this as a write-time
+    # invariant so orphan leaves can't accumulate.
+    parent_subject_group = Column(String(40), nullable=True, index=True)

--- a/src/infra/db/sql/init/tags_init.sql
+++ b/src/infra/db/sql/init/tags_init.sql
@@ -1,0 +1,23 @@
+-- Foundation schema for the unified tag model.
+--
+-- User selections are stored directly on profiles.want_tags / profiles.have_tags
+-- (see profiles ORM), keyed by subject_group; the catalog below maps each
+-- subject_group to its kind and display metadata.
+
+CREATE TABLE IF NOT EXISTS tags (
+    id BIGSERIAL PRIMARY KEY,
+    kind VARCHAR(20) NOT NULL,
+    subject_group VARCHAR(40),
+    "language" VARCHAR(10),
+    "subject" TEXT NOT NULL DEFAULT '',
+    "desc" JSONB,
+    -- NULL ⇔ group row (catalog scaffolding); NOT NULL ⇔ leaf row.
+    -- Strict invariant — _validate_leaves rejects writes that would
+    -- create orphan leaves (no parent), so this single column is enough
+    -- to tell groups and leaves apart.
+    parent_subject_group VARCHAR(40),
+    CONSTRAINT uq_tags_canonical UNIQUE (kind, subject_group, "language", "subject")
+);
+
+CREATE INDEX IF NOT EXISTS idx_tags_kind ON tags(kind);
+CREATE INDEX IF NOT EXISTS ix_tags_parent_subject_group ON tags(parent_subject_group);

--- a/src/infra/db/sql/init/user_init.sql
+++ b/src/infra/db/sql/init/user_init.sql
@@ -71,7 +71,11 @@ CREATE TABLE IF NOT EXISTS profiles (
     topics JSONB,
     expertises JSONB,
     "language" VARCHAR(10),
-    is_mentor BOOLEAN DEFAULT FALSE
+    is_mentor BOOLEAN DEFAULT FALSE,
+    -- Mentor tag selections, flat subject_group arrays. Kind comes from the
+    -- tags catalog (JOIN at read time buckets these into the 5 API fields).
+    want_tags TEXT[] NOT NULL DEFAULT '{}',
+    have_tags TEXT[] NOT NULL DEFAULT '{}'
 );
 
 

--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List, Optional
 
 from fastapi import (
     APIRouter,
@@ -14,11 +15,13 @@ from ...domain.user.model import (
     common_model as common,
     user_model as user,
     reservation_model as reservation,
+    tag_model as tag,
 )
 from ...app.reservation.booking import Booking
 from ...domain.user.service.interest_service import InterestService
 from ...domain.user.service.profession_service import ProfessionService
 from ...domain.user.service.profile_service import ProfileService
+from ...domain.user.service.tag_service import TagService
 from ...infra.databse import get_db, db_session
 
 from ...app._di.injection import (
@@ -27,15 +30,10 @@ from ...app._di.injection import (
     get_profile_service,
     get_reservation_service,
     get_booking_service,
+    get_mentor_profile_app,
+    get_tag_service,
 )
 from ...app.mentor_profile.upsert import MentorProfile
-from ...app._di.injection import (
-    get_interest_service,
-    get_profession_service,
-    get_profile_service,
-    get_mentor_profile_app,
-
-)
 
 log = logging.getLogger(__name__)
 
@@ -149,4 +147,17 @@ async def update_reservation_status(
 ):
     body.my_user_id = user_id
     res = await booking_service.update_reservation_status(db, reservation_id, body)
+    return res_success(data=jsonable_encoder(res))
+
+
+@router.get('/{language}/tags/catalog',
+            responses=idempotent_response('get_tag_catalog', tag.TagCatalogsVO))
+async def get_tag_catalog(
+        language: str = Path(...),
+        kind: Optional[List[TagKind]] = Query(default=None),
+        db: AsyncSession = Depends(db_session),
+        tag_service: TagService = Depends(get_tag_service),
+):
+    # Pass `?kind=skill&kind=topic` to filter; omit for all kinds.
+    res: tag.TagCatalogsVO = await tag_service.get_catalogs(db, kind, language)
     return res_success(data=jsonable_encoder(res))


### PR DESCRIPTION
## Summary
Drops the `user_tags` M:N table; mentor selections live in `profiles.want_tags / have_tags TEXT[]` columns. Five top-level fields on `MentorProfileDTO/VO` (`want_position`, `want_skill`, `want_topic`, `have_skill`, `have_topic`) replace the nested `user_tags` wrapper. `TagIntent.OFFER -> HAVE` end-to-end, then the `TagIntent` enum is dropped (intent is implicit in which array a subject_group lives in). Mentee `ProfileDTO/VO` reverts to no buckets.

Also drops `tags.is_group`: with auto-create gone from `_validate_leaves`, `parent_subject_group IS NULL` means group row, `NOT NULL` means leaf row, so the disambiguation flag is no longer needed.

**Do NOT merge — testing pending.** Only `python -m py_compile` was run; no docker-compose smoke test, no manual psql, no curl roundtrip.

## Pre-deploy when ready
1. DB: `ALTER TABLE profiles ADD want_tags TEXT[] NOT NULL DEFAULT ''{}'', ADD have_tags TEXT[] NOT NULL DEFAULT ''{}''; ALTER TABLE tags DROP COLUMN is_group; DROP TABLE user_tags;`
2. Re-create the `profiles` OpenSearch index with the new flat keyword[] mapping.
3. Seed `tags` catalog before pickers ship — strict validation rejects unknown subject_groups.
4. Frontend cutover to the 5 top-level body fields.

Pairs with X-Career-Search and X-Career-BFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)