### PR TITLE
fix(#226): derive onboarding flag from profiles.want_tags

### DIFF
--- a/src/domain/mentor/service/experience_service.py
+++ b/src/domain/mentor/service/experience_service.py
@@ -70,7 +70,16 @@ class ExperienceService:
             raise ServerException(msg=f'delete experience response failed: user_id: {user_id}, exp_id: {exp_id}')
 
 
-    # 是否為 Onboarding, 透過是否有填寫完個人資料判斷
+    # Onboarding completion gate. Post-#226 the mentee onboarding flow
+    # writes profiles.want_tags; have_tags is mentor-only and stays empty
+    # for plain mentees, so we only check want_tags.
+    @staticmethod
+    def is_onboarded(want_tags: Optional[List[str]]) -> bool:
+        return bool(want_tags)
+
+    # Legacy onboarding check based on the dropped interested_positions /
+    # skills / topics fields. Kept for any external callers; new code
+    # should use is_onboarded(want_tags) instead.
     @staticmethod
     def is_onboarding(all_interests: Optional[Dict[str, List[InterestVO]]]) -> bool:
         if all_interests is None:

--- a/src/domain/mentor/service/mentor_service.py
+++ b/src/domain/mentor/service/mentor_service.py
@@ -59,7 +59,7 @@ class MentorService:
             )
 
             res_vo: MentorProfileVO = await self.__profile_service.convert_to_mentor_profile_vo(
-                db, res_dto, language=language,
+                db, res_dto, language=language, want_tags=res_want,
             )
             await self.__hydrate_buckets(db, res_vo, res_want, res_have, language)
             return res_vo
@@ -78,7 +78,7 @@ class MentorService:
                 raise NotFoundException(msg=f"No such user with id: {user_id}")
             mentor_dto, want_tags, have_tags = row
             res_vo: MentorProfileVO = await self.__profile_service.convert_to_mentor_profile_vo(
-                db, mentor_dto, language=language,
+                db, mentor_dto, language=language, want_tags=want_tags,
             )
             await self.__hydrate_buckets(db, res_vo, want_tags, have_tags, language)
             return res_vo

--- a/src/domain/user/dao/profile_repository.py
+++ b/src/domain/user/dao/profile_repository.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional, Tuple
 
 from sqlalchemy import select, Select, delete as sa_delete
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,15 +9,28 @@ from src.infra.db.orm.init.user_init import Profile
 from src.infra.util.convert_util import get_first_template
 
 
+def _row_to_tuple(row: Profile) -> Tuple[ProfileDTO, List[str], List[str]]:
+    # want_tags / have_tags live on the row but not on ProfileDTO, so
+    # they ride alongside the dto for callers that need them (e.g.
+    # onboarding completion check).
+    return (
+        ProfileDTO.model_validate(row),
+        list(row.want_tags or []),
+        list(row.have_tags or []),
+    )
+
+
 class ProfileRepository:
 
-    async def get_by_user_id(self, db: AsyncSession, user_id: int) -> ProfileDTO:
+    async def get_by_user_id(
+        self, db: AsyncSession, user_id: int,
+    ) -> Tuple[ProfileDTO, List[str], List[str]]:
         stmt: Select = select(Profile).filter(Profile.user_id == user_id)
 
         query: Optional[Profile] = await get_first_template(db, stmt)
         if query is None:
             raise NotFoundException(msg=f"No such user with id: {user_id}")
-        return ProfileDTO.model_validate(query)
+        return _row_to_tuple(query)
 
     async def find_by_user_id(self, db: AsyncSession, user_id: int) -> Optional[ProfileDTO]:
         stmt: Select = select(Profile).filter(Profile.user_id == user_id)
@@ -26,7 +39,9 @@ class ProfileRepository:
             return None
         return ProfileDTO.model_validate(query)
 
-    async def upsert_profile(self, db: AsyncSession, dto: ProfileDTO) -> ProfileDTO:
+    async def upsert_profile(
+        self, db: AsyncSession, dto: ProfileDTO,
+    ) -> Tuple[ProfileDTO, List[str], List[str]]:
         if (dto is None) or (dto.user_id is None):
             raise NotFoundException(msg="not a valid user")
 
@@ -40,13 +55,13 @@ class ProfileRepository:
             db.add(model)
             await db.commit()
             await db.refresh(model)
-            return ProfileDTO.model_validate(model)
+            return _row_to_tuple(model)
 
         for key, value in dto.model_dump().items():
             setattr(existing, key, value)
         await db.commit()
         await db.refresh(existing)
-        return ProfileDTO.model_validate(existing)
+        return _row_to_tuple(existing)
 
     async def delete_profile(self, db: AsyncSession, user_id: int) -> None:
         stmt = sa_delete(Profile).where(Profile.user_id == user_id)

--- a/src/domain/user/service/profile_service.py
+++ b/src/domain/user/service/profile_service.py
@@ -44,10 +44,12 @@ class ProfileService:
             if user_id is None:
                 raise NotAcceptableException(msg="No user interest_id is provided")
 
-            dto: ProfileDTO = await self.__profile_repository.get_by_user_id(
+            dto, want_tags, _ = await self.__profile_repository.get_by_user_id(
                 db, user_id
             )
-            return await self.convert_to_profile_vo(db, dto, language=language)
+            return await self.convert_to_profile_vo(
+                db, dto, language=language, want_tags=want_tags,
+            )
         except Exception as e:
             log.error(f"get_by_user_id error: %s", str(e))
             err_msg = getattr(e, "msg", "get profile response failed")
@@ -55,17 +57,22 @@ class ProfileService:
 
     async def upsert_profile(self, db: AsyncSession, dto: ProfileDTO) -> ProfileVO:
         try:
-            res: Optional[ProfileDTO] = await self.__profile_repository.upsert_profile(
+            res, want_tags, _ = await self.__profile_repository.upsert_profile(
                 db, dto
             )
-            return await self.convert_to_profile_vo(db, res)
+            return await self.convert_to_profile_vo(db, res, want_tags=want_tags)
         except Exception as e:
             log.error(f"upsert_profile error: %s", str(e))
             err_msg = getattr(e, "msg", "upsert profile response failed")
             raise_http_exception(e, msg=err_msg)
 
     async def convert_to_profile_vo(
-        self, db: AsyncSession, dto: ProfileDTO, language: Optional[str] = None
+        self,
+        db: AsyncSession,
+        dto: ProfileDTO,
+        language: Optional[str] = None,
+        *,
+        want_tags: Optional[List[str]] = None,
     ) -> ProfileVO:
         if dto is None:
             raise NotFoundException(msg="no data found")
@@ -102,8 +109,10 @@ class ProfileService:
                     interests=all_interests[InterestCategory.TOPIC.value]
                 )
 
-            # 是否為 Onboarding, 透過是否有填寫完個人資料判斷
-            res.onboarding = ExperienceService.is_onboarding(all_interests)
+            # Onboarding completion is now derived from profiles.want_tags
+            # (mentee onboarding's only required write); the legacy
+            # interested_positions/skills/topics columns are NULL post-#226.
+            res.onboarding = ExperienceService.is_onboarded(want_tags)
             # 是否為 Mentor, 直接使用 dto 的 is_mentor 欄位
             res.is_mentor = dto.is_mentor
             res.language = language
@@ -115,7 +124,12 @@ class ProfileService:
             raise_http_exception(e, msg=err_msg)
 
     async def convert_to_mentor_profile_vo(
-        self, db: AsyncSession, dto: MentorProfileDTO, language: Optional[str] = None
+        self,
+        db: AsyncSession,
+        dto: MentorProfileDTO,
+        language: Optional[str] = None,
+        *,
+        want_tags: Optional[List[str]] = None,
     ) -> MentorProfileVO:
         if dto is None:
             raise NotFoundException(msg="no data found")
@@ -161,8 +175,9 @@ class ProfileService:
 
             # mentor experiences
             res.experiences = experiences
-            # 是否為 Onboarding, 透過是否有填寫完個人資料判斷
-            res.onboarding = ExperienceService.is_onboarding(all_interests)
+            # Same as convert_to_profile_vo — onboarding now derives from
+            # profiles.want_tags rather than the legacy interest fields.
+            res.onboarding = ExperienceService.is_onboarded(want_tags)
             # 是否為 Mentor, 直接使用 dto 的 is_mentor 欄位
             res.is_mentor = dto.is_mentor
             res.language = language


### PR DESCRIPTION
## What Does This PR Do?

- Replace `is_onboarding(all_interests)` with `is_onboarded(want_tags)`
  in `convert_to_profile_vo` / `convert_to_mentor_profile_vo`.
- The legacy check read `profiles.interested_positions / skills / topics`,
  which #226 dropped from the write path — those columns are now always
  NULL, so every freshly-onboarded user came back with `onboarding: false`
  and the FE bounced them back into onboarding on every login.
- Mentee onboarding only writes `profiles.want_tags`; `have_tags` is
  mentor-only and stays empty for plain mentees, so the new gate is just
  `bool(want_tags)`.
- Plumbing: `ProfileRepository.get_by_user_id` / `upsert_profile` now
  return `(dto, want_tags, have_tags)` — same shape `MentorRepository`
  already uses. Callers in `ProfileService` / `MentorService` updated.
- `ExperienceService.is_onboarding(...)` (legacy) is left in place in
  case anything external still imports it; new code uses `is_onboarded`.

## How to Test

1. Pick a user whose `profiles.want_tags` is non-empty (any user that
   completed the onboarding wizard post-#226).
2. `GET /user-service/api/v1/users/{user_id}/{lang}/profile` — expect
   `data.onboarding == true` (was `false` before the fix).
3. Same check via mentor path:
   `GET /user-service/api/v1/mentors/{user_id}/{lang}/mentor_profile`.
4. Negative case: a brand-new user with empty `want_tags` should still
   return `onboarding: false` so the FE shows the wizard.

## Anything to Note?

- Changes the return type of two `ProfileRepository` methods
  (`get_by_user_id`, `upsert_profile`) from `ProfileDTO` to
  `Tuple[ProfileDTO, List[str], List[str]]`. All in-tree callers
  updated; if any downstream branch added a new caller it will need
  the same unpack.
- No DB / endpoint / table changes. Pure read-path fix.
- Pairs with the dev-DB seed + manual mentor backfill done out-of-band
  on 2026-05-02; nothing in this PR depends on those.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
