### PR TITLE
fix: hide cancelled bookings from mentor schedule

### DIFF
--- a/src/domain/mentor/dao/schedule_repository.py
+++ b/src/domain/mentor/dao/schedule_repository.py
@@ -55,12 +55,15 @@ class ScheduleRepository:
         # 條件命中 idx_reservation_user_my_status_dtstart_dtend
         stmt: Select = select(Reservation).filter(
             Reservation.my_user_id == mentor_user_id,
-            Reservation.my_role == RoleType.MENTOR.value,
             Reservation.my_status.in_([
                 BookingStatus.ACCEPT.value,
                 BookingStatus.PENDING.value,
             ]),
-            Reservation.status != BookingStatus.REJECT.value,
+            Reservation.status.in_([
+                BookingStatus.ACCEPT.value,
+                BookingStatus.PENDING.value,
+            ]),
+            Reservation.my_role == RoleType.MENTOR.value,
             Reservation.dtend > window_start_ts,
             Reservation.dtstart < window_end_ts,
         )

--- a/src/domain/mentor/dao/schedule_repository.py
+++ b/src/domain/mentor/dao/schedule_repository.py
@@ -50,6 +50,8 @@ class ScheduleRepository:
         window_end_ts: int,
     ) -> List[Reservation]:
         # mentor 自己這一側為 ACCEPT/PENDING 的預約都要回傳到 schedule segments
+        # 但對方若已 REJECT 就視同預約結束,不該佔住時段
+        # (對方取消時只會更新 status,不會動到 mentor 的 my_status)
         # 條件命中 idx_reservation_user_my_status_dtstart_dtend
         stmt: Select = select(Reservation).filter(
             Reservation.my_user_id == mentor_user_id,
@@ -58,6 +60,7 @@ class ScheduleRepository:
                 BookingStatus.ACCEPT.value,
                 BookingStatus.PENDING.value,
             ]),
+            Reservation.status != BookingStatus.REJECT.value,
             Reservation.dtend > window_start_ts,
             Reservation.dtstart < window_end_ts,
         )


### PR DESCRIPTION
## Summary
- Fix mentor schedule still showing BOOKED after the counterparty cancels an approved reservation.
- The cancel path only flips the participant-side `status` to `REJECT`; the mentor's `my_status` stays `ACCEPT`, so the existing schedule query still returned the row.
- Mirror the reservation list logic by also excluding rows where `Reservation.status == REJECT`.

Reservation list API was already correct (`reservation_repository.py:288-322`); only the schedule query was missing this filter.

## Test plan
- [ ] Mentee approves, then cancels — mentor `GET /mentors/{id}/schedule/...` should no longer include that slot
- [ ] Mentor cancels their own approved booking — slot disappears (regression check)
- [ ] PENDING reservation with no REJECT on either side — still appears as PENDING segment
- [ ] Both sides ACCEPT — still appears as BOOKED segment