### PR TITLE
feat: inline experiences batch in PUT mentor

### DIFF
--- a/src/app/mentor_profile/upsert.py
+++ b/src/app/mentor_profile/upsert.py
@@ -65,7 +65,24 @@ class MentorProfile:
         res: mentor.MentorProfileVO = await self.mentor_service.upsert_mentor_profile(
             db, profile_dto
         )
-        # 若為 is_mentor 狀態，則需通知 Search Service
+        # Inline experiences sync — replace semantics. None means "leave
+        # alone"; [] clears all; [...] becomes the new full set. Each
+        # operation (profile upsert, experiences sync) is internally atomic;
+        # they do not share a single transaction, so a profile-success +
+        # experiences-failure leaves the profile updated. That mirrors
+        # today's separate-endpoint behaviour and is acceptable until a
+        # broader transaction refactor is justified.
+        if profile_dto.experiences is not None:
+            synced_experiences = await self.exp_service.sync_experiences(
+                db=db,
+                user_id=res.user_id,
+                experiences=profile_dto.experiences,
+            )
+            res.experiences = synced_experiences
+        # 若為 is_mentor 狀態，則需通知 Search Service. Single notify
+        # carries both profile and experiences (to_dto_json includes
+        # experiences), replacing the old PUT_MENTOR_PROFILE +
+        # PATCH_MENTOR_PROFILE pair when experiences are inlined.
         if res.is_mentor:
             background_tasks.add_task(
                 self.notify_service.updated_mentor_profile, mentor_profile=res

--- a/src/domain/mentor/dao/mentor_repository.py
+++ b/src/domain/mentor/dao/mentor_repository.py
@@ -14,6 +14,11 @@ _INPUT_BUCKET_FIELDS = {
     'want_position', 'want_skill', 'want_topic', 'have_skill', 'have_topic',
 }
 
+# `experiences` rides on MentorProfileDTO as an optional batch payload but
+# lives in mentor_experiences (synced by ExperienceService.sync_experiences).
+# Strip it before mapping the dto onto Profile columns.
+_NON_PROFILE_FIELDS = _INPUT_BUCKET_FIELDS | {'experiences'}
+
 
 # (dto, want_tags, have_tags) — the storage arrays travel alongside the dto
 # rather than on it, so the API-facing dto stays free of plumbing fields.
@@ -54,7 +59,7 @@ class MentorRepository:
         # Profile columns, and merge would clobber want_tags/have_tags
         # columns the dto doesn't carry. The merged storage arrays come in
         # as kwargs because they're storage state, not API surface.
-        payload = mentor_profile_dto.model_dump(exclude=_INPUT_BUCKET_FIELDS)
+        payload = mentor_profile_dto.model_dump(exclude=_NON_PROFILE_FIELDS)
         payload['want_tags'] = want_tags
         payload['have_tags'] = have_tags
 

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from fastapi.encoders import jsonable_encoder
 from ...user.model.tag_model import TagVO
 from ...user.model.user_model import *
-from .experience_model import ExperienceVO
+from .experience_model import ExperienceDTO, ExperienceVO
 from ....config.conf import *
 from ....config.constant import *
 from ....config.exception import ClientException, UnprocessableClientException
@@ -33,6 +33,14 @@ class MentorProfileDTO(ProfileDTO):
     want_topic: Optional[List[str]] = None
     have_skill: Optional[List[str]] = None
     have_topic: Optional[List[str]] = None
+
+    # Inline experiences batch — replace semantics matching tag buckets:
+    # None = leave alone, [] = clear all, [...] = replace full set.
+    # Items with id are upserted in place; items without id are inserted;
+    # existing experiences whose id isn't in the provided list are deleted.
+    # Stored in mentor_experiences (not on Profile), so the repository
+    # strips this field before mapping the dto onto Profile columns.
+    experiences: Optional[List[ExperienceDTO]] = None
 
     class Config:
         from_attributes = True # orm_mode = True

--- a/src/domain/mentor/service/experience_service.py
+++ b/src/domain/mentor/service/experience_service.py
@@ -54,6 +54,66 @@ class ExperienceService:
             log.error(f'upsert_exp error: %s', str(e))
             raise ServerException(msg='upsert experience response failed')
 
+    async def sync_experiences(
+        self,
+        db: AsyncSession,
+        user_id: int,
+        experiences: List[ExperienceDTO],
+    ) -> List[ExperienceVO]:
+        # Replace semantics: the provided list IS the new full set.
+        # Items with id are upserted; items without id are inserted; any
+        # existing experience whose id isn't in the kept set is deleted.
+        # Single commit at the end so the batch is internally atomic — a
+        # mid-batch failure rolls back to the pre-call state.
+        try:
+            current: List[MentorExperience] = (
+                await self.__exp_dao.get_mentor_exp_list_by_user_id(db, user_id)
+            )
+            current_ids = {e.id for e in current if e.id is not None}
+
+            # Reject ids that aren't owned by this user — db.merge would
+            # otherwise reassign another user's row to user_id (cross-user
+            # clobber). Treat foreign ids as new inserts.
+            sanitized_ids: List[Optional[int]] = []
+            for exp_dto in experiences:
+                if exp_dto.id is not None and exp_dto.id not in current_ids:
+                    log.warning(
+                        'sync_experiences: dropping foreign exp id %s for user %s',
+                        exp_dto.id, user_id,
+                    )
+                    sanitized_ids.append(None)
+                else:
+                    sanitized_ids.append(exp_dto.id)
+
+            kept_ids = {sid for sid in sanitized_ids if sid is not None}
+            ids_to_delete = current_ids - kept_ids
+
+            if ids_to_delete:
+                await self.__exp_dao.delete_by_user_id_in_ids(
+                    db, user_id, ids_to_delete,
+                )
+
+            merged_rows: List[MentorExperience] = []
+            for exp_dto, exp_id in zip(experiences, sanitized_ids):
+                row = MentorExperience(
+                    id=exp_id,
+                    user_id=user_id,
+                    category=exp_dto.category,
+                    order=exp_dto.order,
+                    mentor_experiences_metadata=exp_dto.mentor_experiences_metadata,
+                )
+                merged_rows.append(await db.merge(row))
+
+            await db.commit()
+            for row in merged_rows:
+                await db.refresh(row)
+
+            return [ExperienceVO.model_validate(row) for row in merged_rows]
+        except Exception as e:
+            await db.rollback()
+            log.error(f'sync_experiences error: %s', str(e))
+            raise ServerException(msg='sync experiences response failed')
+
     async def delete_exp_by_user_and_exp_id(self, db: AsyncSession,
                                             user_id: int,
                                             experience_dto: ExperienceDTO) -> bool:

--- a/src/domain/user/dao/mentor_experience_repository.py
+++ b/src/domain/user/dao/mentor_experience_repository.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Iterable, List
 from sqlalchemy import Select, select, and_, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -48,6 +48,22 @@ class MentorExperienceRepository:
 
     async def delete_all_by_user_id(self, db: AsyncSession, user_id: int) -> int:
         stmt = delete(MentorExperience).where(MentorExperience.user_id == user_id)
+        result = await db.execute(stmt)
+        return result.rowcount
+
+    async def delete_by_user_id_in_ids(
+        self, db: AsyncSession, user_id: int, ids: Iterable[int]
+    ) -> int:
+        # No commit — caller batches with other writes (sync_experiences).
+        ids_list = [i for i in ids if i is not None]
+        if not ids_list:
+            return 0
+        stmt = delete(MentorExperience).where(
+            and_(
+                MentorExperience.user_id == user_id,
+                MentorExperience.id.in_(ids_list),
+            )
+        )
         result = await db.execute(stmt)
         return result.rowcount
 


### PR DESCRIPTION
## Summary
- Adds optional `experiences` field to `MentorProfileDTO` so PUT `/mentors/mentor_profile` can sync the full experiences set in one request, matching the per-bucket replace semantics already used for tag buckets (`None` = leave alone, `[]` = clear, `[...]` = replace as the new full set).
- New `ExperienceService.sync_experiences` does a single-commit batch upsert/delete and rejects foreign experience ids (treats them as new inserts) to prevent cross-user clobber via `db.merge`.
- Single Search notify covers both profile and experiences (`to_dto_json` already includes experiences), replacing the `PUT_MENTOR_PROFILE` + `PATCH_MENTOR_PROFILE` pair when experiences are inlined. Old single-experience PUT/DELETE endpoints are kept for incremental frontend rollout.

## Caveats
- Profile upsert and experiences sync each commit independently — a profile-success + experiences-failure leaves the profile updated. Mirrors today`s separate-endpoint behaviour; broader transaction refactor deferred.

## Test plan
- [x] `experiences` omitted -> mentor_experiences untouched
- [x] `experiences=[3 items, no ids]` -> 3 inserts with auto ids
- [x] mixed `[{kept_id}, {kept_id}, {no id}]` with one omitted -> kept rows updated, omitted row deleted, no-id row inserted
- [x] `experiences=[]` -> all rows for user cleared
- [x] foreign exp id from another user -> not clobbered, treated as new insert
- [x] log shows single notify per request (no `PATCH_MENTOR_PROFILE` path when experiences are inlined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)