### PR TITLE
feat: return tag bucket subject_groups instead of full TagVO

### DIFF
--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -3,7 +3,6 @@ from pydantic import BaseModel, Field
 from datetime import datetime
 
 from fastapi.encoders import jsonable_encoder
-from ...user.model.tag_model import TagVO
 from ...user.model.user_model import *
 from .experience_model import ExperienceVO
 from ....config.conf import *
@@ -51,14 +50,15 @@ class MentorProfileVO(ProfileVO):
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
     experiences: Optional[List[ExperienceVO]] = Field(default_factory=list)
 
-    # Hydrated tag buckets — each element is a full TagVO joined from the
-    # catalog (subject, desc, parent_subject_group, etc.). None = not yet
-    # hydrated; [] = no tags in that bucket.
-    want_position: Optional[List[TagVO]] = None
-    want_skill: Optional[List[TagVO]] = None
-    want_topic: Optional[List[TagVO]] = None
-    have_skill: Optional[List[TagVO]] = None
-    have_topic: Optional[List[TagVO]] = None
+    # Bucketed tag subject_groups. Catalog still does the kind lookup
+    # to assign each tag to a bucket, but we send the canonical key only —
+    # frontend resolves display metadata (subject/desc/etc.) on its side
+    # to keep the wire payload small. None = not yet bucketed; [] = empty.
+    want_position: Optional[List[str]] = None
+    want_skill: Optional[List[str]] = None
+    want_topic: Optional[List[str]] = None
+    have_skill: Optional[List[str]] = None
+    have_topic: Optional[List[str]] = None
 
     @staticmethod
     def of(mentor_profile_dto: MentorProfileDTO) -> 'MentorProfileVO':
@@ -78,8 +78,9 @@ class MentorProfileVO(ProfileVO):
         )
 
     def to_dto_json(self):
-        # Search consumes flat subject_group arrays per bucket — full TagVO
-        # would be wasted bytes on the wire (Search only filters by key).
+        # Search consumes flat subject_group arrays per bucket — same shape
+        # the API now exposes to the frontend, so the buckets pass through
+        # unchanged.
         return {
             'user_id': self.user_id,
             'name': self.name,
@@ -95,18 +96,12 @@ class MentorProfileVO(ProfileVO):
             'about': self.about,
             'seniority_level': self.seniority_level.value if self.seniority_level else None,
             'experiences': jsonable_encoder(self.experiences),
-            'want_position': self._tag_subject_groups(self.want_position),
-            'want_skill': self._tag_subject_groups(self.want_skill),
-            'want_topic': self._tag_subject_groups(self.want_topic),
-            'have_skill': self._tag_subject_groups(self.have_skill),
-            'have_topic': self._tag_subject_groups(self.have_topic),
+            'want_position': self.want_position or [],
+            'want_skill': self.want_skill or [],
+            'want_topic': self.want_topic or [],
+            'have_skill': self.have_skill or [],
+            'have_topic': self.have_topic or [],
         }
-
-    @staticmethod
-    def _tag_subject_groups(tags: Optional[List[TagVO]]) -> List[str]:
-        if not tags:
-            return []
-        return [t.subject_group for t in tags if t.subject_group]
 
 
 class TimeSlotDTO(BaseModel):

--- a/src/domain/user/service/tag_service.py
+++ b/src/domain/user/service/tag_service.py
@@ -14,7 +14,6 @@ from src.domain.user.model.tag_model import (
     TagCatalogLeafVO,
     TagCatalogVO,
     TagCatalogsVO,
-    TagVO,
 )
 
 log = logging.getLogger(__name__)
@@ -189,11 +188,12 @@ class TagService:
         want_tags: List[str],
         have_tags: List[str],
         language: str,
-    ) -> Dict[str, List[TagVO]]:
+    ) -> Dict[str, List[str]]:
         # Single bulk JOIN of all tagged subject_groups, then bucketed by
         # (which-array, kind=catalog row). Items not found in the catalog
-        # drop out — they don't belong to any bucket.
-        result: Dict[str, List[TagVO]] = {
+        # drop out — they don't belong to any bucket. Returns subject_group
+        # keys only; frontend resolves display metadata on its side.
+        result: Dict[str, List[str]] = {
             'want_position': [], 'want_skill': [], 'want_topic': [],
             'have_skill': [], 'have_topic': [],
         }
@@ -220,7 +220,7 @@ class TagService:
                         # e.g. position written into have_tags somehow —
                         # not a valid combination; skip rather than crash.
                         continue
-                    result[bucket].append(TagVO.model_validate(tag))
+                    result[bucket].append(sg)
             return result
         except Exception as e:
             log.error("hydrate_buckets error: %s", str(e))


### PR DESCRIPTION
## Summary
- `GET /mentors/{user_id}/{language}/mentor_profile` (and the matching PUT response) now returns plain subject_group strings for the 5 tag buckets — `[python, react]` instead of `[{subject_group, subject, desc, ...}, ...]`. Frontend resolves display strings on its side.
- The catalog JOIN is still needed to bucket each tag by `kind`, but the per-row metadata is dropped before responding.
- Search payload (`to_dto_json`) was already flat subject_groups, so the wire format Search consumes is unchanged.

## Files
- `MentorProfileVO`: bucket fields `List[TagVO]` -> `List[str]`
- `TagService.hydrate_buckets`: returns `Dict[str, List[str]]`
- Drop `_tag_subject_groups` helper and `TagVO` imports made unused

## Test plan
- [x] GET `/mentors/1/en_US/mentor_profile` -> buckets are flat string arrays (`want_skill: [python]`)
- [x] PUT `/mentors/mentor_profile` -> response buckets are flat string arrays in the same shape
- [x] Verified full GET response JSON: no nested TagVO objects under any of the 5 buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)