### PR TITLE
fix: restore TagVO import in tag_service

### DIFF
--- a/src/domain/user/service/tag_service.py
+++ b/src/domain/user/service/tag_service.py
@@ -14,6 +14,7 @@ from src.domain.user.model.tag_model import (
     TagCatalogLeafVO,
     TagCatalogVO,
     TagCatalogsVO,
+    TagVO,
 )
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- `tag_service.TagService.hydrate_flat_tag` references `TagVO` (return type annotation + `TagVO.model_validate(...)` in body), but the import was dropped in 02dde31 ("feat: return tag bucket subject_groups instead of full TagVO").
- Module load on `dev` fails immediately with `NameError: name 'TagVO' is not defined`, so the User service can't start at all.
- Re-add `TagVO` to the `tag_model` import to unblock startup.

## Test plan
- [x] Reproduce: `docker compose up user` on `dev` → uvicorn worker crashes with NameError before serving any request
- [x] Apply fix → `User Application startup complete.`
- [x] `GET /user-service/yolo` → `200 {"mention":"You only live once."}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)