### PR TITLE
fix(ci): wait for Lambda update before patching env vars

### DIFF
--- a/.github/workflows/cicd-dev.yaml
+++ b/.github/workflows/cicd-dev.yaml
@@ -49,6 +49,14 @@ jobs:
           THE_REGION: ${{ secrets.AWS_REGION }}
           ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
 
+      # Block until Lambda's CloudFormation rollout has fully settled.
+      # Without this, `update-function-configuration` below can race the
+      # in-progress deploy and get its env vars (DB_*, SEARCH_SERVICE_URL,
+      # etc.) overwritten when the rollout finishes with serverless.yml's
+      # smaller environment block.
+      - name: Wait for Lambda update to settle
+        run: aws lambda wait function-updated --function-name x-career-user-dev-app
+
       - name: Update Lambda environment variables
         env:
           XC_BUCKET: ${{ secrets.XC_BUCKET_DEV }}


### PR DESCRIPTION
## Summary

Insert `aws lambda wait function-updated` between the `sls deploy` step and the `update-function-configuration` step in `cicd-dev.yaml`. Mirrors the fix in [X-Career-BFF PR #146](https://github.com/Xchange-Taiwan/X-Career-BFF/pull/146).

## Root cause

The dev workflow has two consecutive Lambda-touching steps:

1. **`npx sls deploy`** — CloudFormation build, applies `serverless.yml`'s small env block.
2. **`aws lambda update-function-configuration`** — overlays the full env block: `DB_HOST`, `DB_PASSWORD`, `DB_USER`, `DB_NAME`, `SEARCH_SERVICE_URL`, `AUTH_SERVICE_URL`, `SQS_QUEUE_URL`, etc.

`sls deploy` returns when CloudFormation reports stack-level completion, but the Lambda function can still be in `LastUpdateStatus: InProgress`. When the rollout finally settles *after* step 2 runs, it does so with `serverless.yml`'s smaller env block — wiping what step 2 just set.

## Symptom on dev

After PR #114's deploy today, every endpoint that touches Postgres returns `code:50000 / "Internal Server Error"`:

```
GET /v1/users/zh_TW/tags/catalog              → 500
GET /v1/users/zh_TW/tags/catalog?kind=industry → 500
GET /v1/users/1/zh_TW/profile                  → 500
```

But `/dev/docs` and `/user-service/<term>` (no DB) return 200/418 normally — Lambda itself is alive. The problem is `os.getenv('DB_HOST', 'localhost')` etc. falling back to localhost defaults because the env vars never stuck.

This was also the upstream cause of the `code:50000 / "All connection attempts failed"` symptom on the BFF — BFF reaches User service via `USER_SERVICE_URL`, but User service then can't reach its own DB.

## Test plan

- [ ] Merge → CI/CD runs on push to dev → log shows the new "Wait for Lambda update to settle" step blocking until function exits `InProgress`
- [ ] Subsequent `Update Lambda environment variables` step succeeds with `LastUpdateStatus: Successful`
- [ ] `aws lambda get-function-configuration --function-name x-career-user-dev-app --query Environment.Variables` shows all 25 vars after CI/CD finishes
- [ ] `GET /v1/users/zh_TW/tags/catalog?kind=industry` returns 200 with the 16 zh_TW industry rows
- [ ] BFF's `GET /dev/api/v1/users/zh_TW/tags/catalog` returns 200 (full chain works)

## Note

X-Career-Auth and X-Career-Search likely have the same workflow pattern and should get the same fix as a follow-up. Out of scope for unblocking dev today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
