### PR TITLE
fix(conf): strip whitespace on string env vars (root cause: GET /tags/catalog 500 on dev)

### DIFF
--- a/src/config/conf.py
+++ b/src/config/conf.py
@@ -1,25 +1,25 @@
 import os
 
 
-XC_BUCKET = os.getenv('XC_BUCKET', 'xc-bucket')
-XC_USER_BUCKET = os.getenv('XC_USER_BUCKET', 'xc-user-bucket')
+XC_BUCKET = os.getenv('XC_BUCKET', 'xc-bucket').strip()
+XC_USER_BUCKET = os.getenv('XC_USER_BUCKET', 'xc-user-bucket').strip()
 BATCH = int(os.getenv('BATCH', 20))
 MAX_PERIOD_SECS = int(os.getenv('MAX_PERIOD_SECS', 86400 * 31))
-DATETIME_FORMAT = os.getenv('DATETIME_FORMAT', '%Y%m%dT%H%M%S%z')
-DEFAULT_LANGUAGE = os.getenv('DEFAULT_LANGUAGE', 'zh_TW')
+DATETIME_FORMAT = os.getenv('DATETIME_FORMAT', '%Y%m%dT%H%M%S%z').strip()
+DEFAULT_LANGUAGE = os.getenv('DEFAULT_LANGUAGE', 'zh_TW').strip()
 # resource probe cycle secs
 PROBE_CYCLE_SECS = int(os.getenv("PROBE_CYCLE_SECS", 3))
 
 # default cache ttl: 5 minutes
 CACHE_TTL = int(os.getenv('CACHE_TTL', 300))
 # db config params
-DB_HOST = os.getenv('DB_HOST', 'localhost')
-DB_PORT = os.getenv('DB_PORT', '5432')
-DB_USER = os.getenv('DB_USER', 'user')
-DB_PASSWORD = os.getenv('DB_PASSWORD', 'pass')
-DB_NAME = os.getenv('DB_NAME', 'db')
+DB_HOST = os.getenv('DB_HOST', 'localhost').strip()
+DB_PORT = os.getenv('DB_PORT', '5432').strip()
+DB_USER = os.getenv('DB_USER', 'user').strip()
+DB_PASSWORD = os.getenv('DB_PASSWORD', 'pass').strip()
+DB_NAME = os.getenv('DB_NAME', 'db').strip()
 DB_SCHEMA = os.getenv('DB_SCHEMA', 'public').strip()
-RESERVATION_ISOLAION_LEVEL = os.getenv('RESERVATION_ISOLAION_LEVEL', 'SERIALIZABLE')
+RESERVATION_ISOLAION_LEVEL = os.getenv('RESERVATION_ISOLAION_LEVEL', 'SERIALIZABLE').strip()
 
 # db connection pool config params
 # 資料庫連接池配置 - 可通過環境變量覆蓋默認值
@@ -34,8 +34,8 @@ DB_COMMAND_TIMEOUT = int(os.getenv('DB_COMMAND_TIMEOUT', 60))   # 命令超時�
 DB_JIT_OFF = int(os.getenv('DB_JIT_OFF', 1))    # 是否關閉 PostgreSQL JIT (提高穩定性)
 DB_JIT_OFF = True if DB_JIT_OFF >= 1 else False
 
-SEARCH_SERVICE_URL = os.getenv('SEARCH_SERVICE_URL', 'http://127.0.0.1:8012/search-service/api')
-AUTH_SERVICE_URL = os.getenv('AUTH_SERVICE_URL', 'http://127.0.0.1:8008/auth-service/api')
+SEARCH_SERVICE_URL = os.getenv('SEARCH_SERVICE_URL', 'http://127.0.0.1:8012/search-service/api').strip()
+AUTH_SERVICE_URL = os.getenv('AUTH_SERVICE_URL', 'http://127.0.0.1:8008/auth-service/api').strip()
     
 
 # sqs/event bus conf
@@ -45,4 +45,4 @@ MQ_MAX_ATTEMPTS = int(os.getenv("MQ_MAX_ATTEMPTS", 3))
 
 # sqs
 # for retry failed pub events
-SQS_QUEUE_URL = os.getenv('SQS_QUEUE_URL', 'https://sqs.{REGION}.amazonaws.com/{ACCOUNT_ID}/{QUEUE_NAME}')
+SQS_QUEUE_URL = os.getenv('SQS_QUEUE_URL', 'https://sqs.{REGION}.amazonaws.com/{ACCOUNT_ID}/{QUEUE_NAME}').strip()

--- a/src/config/conf.py
+++ b/src/config/conf.py
@@ -18,7 +18,7 @@ DB_PORT = os.getenv('DB_PORT', '5432')
 DB_USER = os.getenv('DB_USER', 'user')
 DB_PASSWORD = os.getenv('DB_PASSWORD', 'pass')
 DB_NAME = os.getenv('DB_NAME', 'db')
-DB_SCHEMA = os.getenv('DB_SCHEMA', 'public')
+DB_SCHEMA = os.getenv('DB_SCHEMA', 'public').strip()
 RESERVATION_ISOLAION_LEVEL = os.getenv('RESERVATION_ISOLAION_LEVEL', 'SERIALIZABLE')
 
 # db connection pool config params


### PR DESCRIPTION
## Summary

- Add `.strip()` to every string-typed `os.getenv` in `src/config/conf.py` so a trailing whitespace on any env var no longer cascades into runtime failures.
- Triggered by a real outage today: dev `GET /users/{lang}/tags/catalog` returned 500 across all `kind` x `language` combinations.

## Root cause

CloudWatch on `x-career-user-dev-app` showed:

```
asyncpg.exceptions.UndefinedTableError: relation tags does not exist
[SQL: SELECT tags.id, ... FROM tags WHERE tags.kind = $1 AND tags.language = $2 ...]
```

`x-career-dev.tags` exists (16+46+39+18 zh_TW rows), so the table was clearly there — the connection was just not finding it on the `search_path`. `aws lambda get-function-configuration` revealed:

```json
DB_SCHEMA: x-career-dev\n
```

Trailing newline. `databse.py` interpolates that straight into asyncpg `server_settings`:

```python
server_settings[search_path] = f'{DB_SCHEMA}, public'
```

so the actual SET command was `search_path = x-career-dev\n, public`, which postgres could not resolve to a real schema, and unqualified ORM queries fell back to `public`. `tags` lives only in `x-career-dev`, so every `SELECT` from `Tag` errored.

The newline almost certainly originated from the GitHub `DB_SCHEMA_DEV` secret being uploaded with a stray newline; `cicd-dev.yaml` then forwards `secrets.DB_SCHEMA_DEV` to the Lambda env var verbatim, so every deploy reproduces it.

## Fix scope

- **First commit** patches `DB_SCHEMA` specifically (the active outage).
- **Second commit** extends the same `.strip()` to the other 13 string env vars in `conf.py`. Same risk class — they all flow from the same GitHub Actions secret upload path. `int()`-wrapped numeric env vars are skipped because `int(20\n)` already trims.

This is defense at the boundary; it does **not** depend on the GitHub secret being clean or the CI step being changed. Either of those is still worth doing as a follow-up (re-upload `DB_SCHEMA_DEV` without the newline) but they no longer block recovery.

## Out of scope (follow-ups)

- The actual GitHub `DB_SCHEMA_DEV` secret value still has `\n`. Until it is re-uploaded, the live Lambda env var keeps regenerating with the newline on every deploy — but with this PR merged, `.strip()` neutralises it at runtime.
- The live dev Lambda still has the bad env var right now; either deploy this PR or run a one-shot `aws lambda update-function-configuration` to clear `DB_SCHEMA` to `x-career-dev` to restore the API immediately.

## Test plan

- [ ] Merge to `dev`, let `cicd-dev.yaml` redeploy
- [ ] Hit `GET /dev/user-service/api/v1/users/zh_TW/tags/catalog?kind=industry` — expect 200 with 16 group rows
- [ ] Hit same with `kind=position|skill|topic` — expect 200 with group+leaf nesting
- [ ] Hit with `language=en_US` — expect 200 with empty groups (no en_US seed yet, this is correct)
- [ ] CloudWatch should no longer show `relation tags does not exist`