### PR TITLE
fix(reservation): skip dead rows in conflict check after counterparty cancel

### DIFF
--- a/src/domain/user/dao/reservation_repository.py
+++ b/src/domain/user/dao/reservation_repository.py
@@ -112,6 +112,27 @@ class ReservationRepository:
         return [ReservationVO.model_validate(reservation) for reservation in reservations]
 
 
+    async def find_accepted_overlapping(self, db: AsyncSession,
+                                        my_user_id: int,
+                                        dtstart: int,
+                                        dtend: int) -> List[ReservationVO]:
+        # When the counterparty cancels, only their `my_status` flips to REJECT;
+        # this user's row keeps `my_status=ACCEPT` (status=REJECT mirrors the
+        # counterparty). Filtering on my_status=ACCEPT alone treats those dead
+        # rows as live conflicts and blocks re-booking the same slot.
+        stmt: Select = select(Reservation).where(
+            and_(
+                Reservation.my_user_id == my_user_id,
+                Reservation.my_status == BookingStatus.ACCEPT,
+                Reservation.status != BookingStatus.REJECT,
+                Reservation.dtstart >= dtstart,
+                Reservation.dtend <= dtend,
+            )
+        )
+        reservations = await get_all_template(db, stmt)
+        return [ReservationVO.model_validate(reservation) for reservation in reservations]
+
+
     async def save_all(self, db: AsyncSession, reservations: List[Reservation]):
         log.info(f"=== save_all 开始执行 ===")
         log.info(f"Reservations 数量: {len(reservations)}")

--- a/src/domain/user/service/reservation_service.py
+++ b/src/domain/user/service/reservation_service.py
@@ -256,16 +256,16 @@ class ReservationService:
     '''
 
     async def check_my_accepted_bookings(self, db: AsyncSession, reservation_dto: ReservationDTO):
-        dtstart = reservation_dto.dtstart
-        dtend = reservation_dto.dtend
-        query: Dict = {
-            'my_user_id': reservation_dto.my_user_id,
-            'my_status': BookingStatus.ACCEPT,
-        }
-
-        # check sender's reservations
-        sender_reserve_list: Optional[List[ReservationDTO]] = \
-            await self.reservation_repo.find_all(db, query, dtstart, dtend)
+        # Skip rows where the counterparty has already cancelled (status=REJECT)
+        # — those reservations are dead and must not block a fresh booking on
+        # the same slot. find_accepted_overlapping enforces this at the DB level.
+        sender_reserve_list: List[ReservationVO] = \
+            await self.reservation_repo.find_accepted_overlapping(
+                db,
+                my_user_id=reservation_dto.my_user_id,
+                dtstart=reservation_dto.dtstart,
+                dtend=reservation_dto.dtend,
+            )
 
         if len(sender_reserve_list) > 0:
             sender_reserve_dict = {idx+1: jsonable_encoder(r) for idx, r in enumerate(sender_reserve_list)}


### PR DESCRIPTION
## Summary

- Mentee can now re-book the same slot after the mentor accepts then cancels. Previously `check_my_accepted_bookings` filtered on `my_status=ACCEPT` alone, so the mentee''s row — whose `my_status` stays ACCEPT after a counterparty cancel — was treated as a live conflict and produced `reservation conflict`.
- Adds `ReservationRepository.find_accepted_overlapping` which additionally requires `status != REJECT`, mirroring the fix shipped earlier for `find_active_duplicate` (#aa7a7ac). The service-layer conflict check routes through it.

## Why this slipped past the earlier fix

After mentor cancels:
| row | `my_status` | `status` |
|---|---|---|
| mentor | REJECT | ACCEPT |
| mentee | **ACCEPT** | REJECT |

Every list view (`MENTEE_UPCOMING` / `MENTEE_PENDING` / `MENTEE_HISTORY`) already excludes rows where either side is REJECT, so the dead row never surfaces in UI. But `check_my_accepted_bookings` ran before `check_duplicate_reservation` in the create flow and only looked at the user''s own `my_status`, so it threw before the (correct) duplicate guard ever ran.

## Test plan

- [ ] Manual: mentee A books mentor B → B accepts → B cancels → A re-books same slot → succeeds
- [ ] Manual: mentee A books mentor B → both ACCEPT → A tries to double-book the same slot with mentor C → still blocked with `reservation conflict`
- [ ] Manual: mentee A has an ACCEPTed slot with mentor B (live, neither side rejected) → A tries any other booking that overlaps that window → still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)