### PR TITLE
fix(reservation): skip dead partner rows when updating status

### DIFF
--- a/src/domain/user/dao/reservation_repository.py
+++ b/src/domain/user/dao/reservation_repository.py
@@ -73,6 +73,25 @@ class ReservationRepository:
         return ReservationVO.model_validate(reservation)
 
 
+    async def find_active_one(self, db: AsyncSession,
+                              query: Dict) -> Optional[ReservationVO]:
+        # Same key as find_one but excludes REJECT rows on either side.
+        # When the same slot is re-booked after a cancel, the dead row and
+        # the live row share (my_user_id, schedule_id, dtstart, dtend, user_id);
+        # filter_by alone can return the dead row and trip the partial unique
+        # index on the next status update.
+        stmt: Select = select(Reservation).filter_by(**query).where(
+            and_(
+                Reservation.my_status != BookingStatus.REJECT,
+                Reservation.status != BookingStatus.REJECT,
+            )
+        )
+        reservation = await get_first_template(db, stmt)
+        if not reservation:
+            return None
+        return ReservationVO.model_validate(reservation)
+
+
     async def find_active_duplicate(self, db: AsyncSession,
                                     schedule_id: int,
                                     dtstart: int,

--- a/src/domain/user/service/reservation_service.py
+++ b/src/domain/user/service/reservation_service.py
@@ -312,8 +312,11 @@ class ReservationService:
     async def get_participant_vo(self, db: AsyncSession,
                                  update_dto: UpdateReservationDTO) -> Optional[ReservationVO]:
         p_query = update_dto.participant_query()
+        # Must exclude REJECT rows: a cancelled-then-rebooked slot has both
+        # a dead row and a live row sharing the same partner-query key, and
+        # updating the dead row trips the partial unique index.
         participant_vo: ReservationVO = \
-            await self.reservation_repo.find_one(db, p_query)
+            await self.reservation_repo.find_active_one(db, p_query)
         if not participant_vo:
             log.error('participant reservation not found, query: %s', p_query)
             raise ClientException(msg='participant reservation not found')
@@ -337,8 +340,11 @@ class ReservationService:
     async def get_prev_participant_vo(self, db: AsyncSession,
                                       prev_sender_vo: ReservationVO) -> Optional[ReservationVO]:
         p_query = prev_sender_vo.participant_query()
+        # Same active-row filter as get_participant_vo: the partner of the
+        # row we're about to REJECT must itself still be live, otherwise we
+        # could pick up an older dead pair from a prior cancel cycle.
         prev_participant_vo: ReservationVO = \
-            await self.reservation_repo.find_one(db, p_query)
+            await self.reservation_repo.find_active_one(db, p_query)
 
         if not prev_participant_vo:
             log.error('previous participant reservation not found, \


### PR DESCRIPTION
## Summary

- Follow-up to #118: same dead-row class of bug, but in the partner-row lookup during `update_reservation_status` instead of the create path.
- After cancel + re-book on the same slot, `get_participant_vo` could pick the dead row (REJECT pair) over the live row because both share the partner-query key. The subsequent UPDATE flipped the dead row''s `my_status`/`status` back to ACCEPT and tripped the partial unique index from `7758264` against the live row.
- Adds `ReservationRepository.find_active_one` (= `find_one` + `my_status != REJECT AND status != REJECT`) and routes both `get_participant_vo` and `get_prev_participant_vo` through it.

## Why this surfaces now

PR #118 fixed the create-path duplicate check, so re-booking the same slot now succeeds and we end up with both a dead pair and a live pair sharing the partner-query key. Before #118, the create itself was blocked, so the partner-lookup-with-no-status-filter never had two rows to choose between.

CloudWatch confirmed the pattern: mentor PUTs `/reservations/11` (live mentor row) → service updates `id=7` (dead mentee row) → `UniqueViolationError` on `uidx_reservation_active_user_dtstart_dtend_schedule_id_user_id`.

## Scope

- `saga_reservation_service.py` has the same pattern but is dead code (only `ReservationService` is wired in `src/app/_di/injection.py`), intentionally left untouched.

## Test plan

- [ ] mentee book → mentor accept → mentor cancel → mentee re-book same slot → mentor accept (the failing flow)
- [ ] regression: mentor accept on a slot with no prior cancel still works
- [ ] reschedule flow (`create_new_and_reject_previous`) still finds the previous-pair partner correctly