### PR TITLE
chore(sqs): split queues by environment

### DIFF
--- a/.github/workflows/cicd-dev.yaml
+++ b/.github/workflows/cicd-dev.yaml
@@ -48,6 +48,8 @@ jobs:
           STAGE: dev
           THE_REGION: ${{ secrets.AWS_REGION }}
           ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          SQS_QUEUE_ARN: ${{ secrets.SQS_QUEUE_ARN }}
+          SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
 
       # Block until Lambda's CloudFormation rollout has fully settled.
       # Without this, `update-function-configuration` below can race the
@@ -119,3 +121,21 @@ jobs:
               }
             }' > /tmp/user-lambda-update.json
           aws lambda update-function-configuration --cli-input-json file:///tmp/user-lambda-update.json
+
+      - name: Verify SQS configuration
+        env:
+          SQS_QUEUE_ARN: ${{ secrets.SQS_QUEUE_ARN }}
+          SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
+        run: |
+          aws lambda wait function-updated --function-name x-career-user-dev-app
+          ACTUAL_QUEUE_URL="$(aws lambda get-function-configuration \
+            --function-name x-career-user-dev-app \
+            --query 'Environment.Variables.SQS_QUEUE_URL' \
+            --output text)"
+          test "$ACTUAL_QUEUE_URL" = "$SQS_QUEUE_URL"
+          aws sqs get-queue-attributes \
+            --queue-url "$SQS_QUEUE_URL" \
+            --attribute-names QueueArn \
+            --query "Attributes.QueueArn == '$SQS_QUEUE_ARN'" \
+            --output text | grep -q True
+          echo "Verified dev User Lambda SQS configuration."

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,6 +11,7 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: prod
 
     steps:
       - name: Checkout repository
@@ -47,6 +48,8 @@ jobs:
           STAGE: prod
           THE_REGION: ${{ secrets.AWS_REGION }}
           ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          SQS_QUEUE_ARN: ${{ secrets.SQS_QUEUE_ARN }}
+          SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
 
       # Block until Lambda's CloudFormation rollout has fully settled.
       # Without this, `update-function-configuration` below can race the
@@ -118,3 +121,21 @@ jobs:
               }
             }' > /tmp/user-lambda-update.json
           aws lambda update-function-configuration --cli-input-json file:///tmp/user-lambda-update.json
+
+      - name: Verify SQS configuration
+        env:
+          SQS_QUEUE_ARN: ${{ secrets.SQS_QUEUE_ARN }}
+          SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
+        run: |
+          aws lambda wait function-updated --function-name x-career-user-prod-app
+          ACTUAL_QUEUE_URL="$(aws lambda get-function-configuration \
+            --function-name x-career-user-prod-app \
+            --query 'Environment.Variables.SQS_QUEUE_URL' \
+            --output text)"
+          test "$ACTUAL_QUEUE_URL" = "$SQS_QUEUE_URL"
+          aws sqs get-queue-attributes \
+            --queue-url "$SQS_QUEUE_URL" \
+            --attribute-names QueueArn \
+            --query "Attributes.QueueArn == '$SQS_QUEUE_ARN'" \
+            --output text | grep -q True
+          echo "Verified prod User Lambda SQS configuration."

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,7 +11,6 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: prod
 
     steps:
       - name: Checkout repository

--- a/serverless.yml
+++ b/serverless.yml
@@ -71,7 +71,7 @@ provider:
           - "sqs:ReceiveMessage"
           - "sqs:DeleteMessage"
         Resource: 
-          - "arn:aws:sqs:${env:THE_REGION}:${env:ACCOUNT_ID}:X_CAREER_USER_DUPLICATE_QUEUE.fifo"
+          - ${env:SQS_QUEUE_ARN}
 
 # you can define service wide environment variables here
 #  environment:
@@ -116,6 +116,7 @@ functions:
     handler: main.handler
     environment:
       STAGE: ${self:provider.stage}
+      SQS_QUEUE_URL: ${env:SQS_QUEUE_URL}
     layers:
     - {Ref: PythonRequirementsLambdaLayer}
     events:


### PR DESCRIPTION
Use GitHub environment secrets for the SQS ARN/URL, route prod and dev User Lambda producers to separate FIFO queues, and verify the Lambda queue URL after deployment.